### PR TITLE
Bug in filling land values in previous bathy commit

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2064,7 +2064,7 @@ class experiment:
         ## This preserves the true land/ocean mask.
         bathymetry["depth"] = bathymetry["depth"].where(bathymetry["depth"] > 0, np.nan)
         bathymetry["depth"] = bathymetry["depth"].where(
-            ~(bathymetry.depth <= self.min_depth), self.min_depth + 0.1
+            ~(bathymetry.depth <= self.minimum_depth), self.minimum_depth + 0.1
         )
         bathymetry = bathymetry.fillna(
             0


### PR DESCRIPTION
Updated bathymetry depth handling to not fill land to above the minimum depth, instead it changes the land to NaN, fills the ocean to minimum depth, then changes the NaN to zero