### PR TITLE
Remove Python versions 3.9 and 3.10 from testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since 3.9 is at end of life and 3.10 is beyond support window, I've removed them from testing

closes #270 