### PR TITLE
Get mom6_forge from PyPi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "f90nml >= 1.4.1",
   "copernicusmarine >= 2.0.0,<2.1.0",
   "pint_xarray",
-  "mom6_forge @ git+https://github.com/NCAR/mom6_forge.git@main"
+  "mom6_forge"
 ]
 
 [build-system]


### PR DESCRIPTION
mom6_forge was being pulled from git, it is now being pulled from PyPi instead.