### PR TITLE
Chill overzealous info logging to debug, remove setup_logger

### DIFF
--- a/regional_mom6/__init__.py
+++ b/regional_mom6/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 try:
     from ._version import __version__
 except ImportError:

--- a/regional_mom6/config.py
+++ b/regional_mom6/config.py
@@ -5,9 +5,9 @@ import inspect
 from pathlib import Path
 import datetime as dt
 import xarray as xr
-from regional_mom6.utils import setup_logger
+import logging
 
-config_logger = setup_logger(__name__, set_handler=False)
+config_logger = logging.getLogger(__name__)
 
 
 class Config:

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -27,10 +27,11 @@ from pathlib import Path
 import dask.array as da
 import numpy as np
 import netCDF4
-from regional_mom6.utils import setup_logger, get_edge
+import logging
+from regional_mom6.utils import get_edge
 from os.path import isfile
 
-regridding_logger = setup_logger(__name__, set_handler=False)
+regridding_logger = logging.getLogger(__name__)
 
 
 def coords(
@@ -69,7 +70,7 @@ def coords(
     dataset_to_get_coords = None
 
     if coords_at_t_points:
-        regridding_logger.info("Creating coordinates of the boundary t-points")
+        regridding_logger.debug("Creating coordinates of the boundary t-points")
 
         # Calculate t-point information
         ds = get_hgrid_arakawa_c_points(hgrid, "t")
@@ -85,7 +86,7 @@ def coords(
             coords={"nyp": ds.nyp, "nxp": ds.nxp},
         )
     else:
-        regridding_logger.info("Creating coordinates of the boundary q/u/v points")
+        regridding_logger.debug("Creating coordinates of the boundary q/u/v points")
         # Don't have to do anything because this is the actual boundary.
         # t-points are one-index deep and require managing.
         dataset_to_get_coords = hgrid
@@ -167,7 +168,7 @@ def get_hgrid_arakawa_c_points(hgrid: xr.Dataset, point_type="t") -> xr.Dataset:
     if point_type not in "uvqth":
         raise ValueError("point_type must be one of 'uvqht'")
 
-    regridding_logger.info("Getting {} points..".format(point_type))
+    regridding_logger.debug("Getting {} points..".format(point_type))
 
     # Figure out the maths for the offset
     k = 2
@@ -238,7 +239,7 @@ def create_regridder(
     xe.Regridder
         The regridding object
     """
-    regridding_logger.info("Creating Regridder")
+    regridding_logger.debug("Creating Regridder")
 
     weights_exist = bool(outfile) and isfile(outfile)
     if weights_exist:
@@ -283,7 +284,7 @@ def fill_missing_data(
         Type: Python Functions, Source Code
         Web Address: https://github.com/jsimkins2/nwa25
     """
-    regridding_logger.info("Filling in missing data horizontally, then vertically")
+    regridding_logger.debug("Filling in missing data horizontally, then vertically")
     if fill == "f":
         filled = ds.ffill(dim=xdim, limit=None)
     elif fill == "b":
@@ -308,7 +309,7 @@ def add_or_update_time_dim(ds: xr.Dataset, times, z_dims=None) -> xr.Dataset:
     Returns:
         (xr.Dataset): The dataset with the time dimension added
     """
-    regridding_logger.info("Adding time dimension")
+    regridding_logger.debug("Adding time dimension")
 
     regridding_logger.debug(f"Times: {times}")
     regridding_logger.debug(f"Make sure times is a DataArray")
@@ -374,7 +375,7 @@ def add_secondary_dimension(
     """
 
     # Check if we need to insert the dim earlier or later
-    regridding_logger.info("Adding perpendicular dimension to {}".format(var))
+    regridding_logger.debug("Adding perpendicular dimension to {}".format(var))
 
     regridding_logger.debug(
         "Checking if nz or constituent is in dimensions, then we have to bump the perpendicular dimension up by one"
@@ -420,13 +421,13 @@ def vertical_coordinate_encoding(
         The old vertical coordinate name
     """
 
-    regridding_logger.info("Renaming vertical coordinate to nz_... in {}".format(var))
+    regridding_logger.debug("Renaming vertical coordinate to nz_... in {}".format(var))
     section = "_seg"
     base_var = var[: var.find(section)] if section in var else var
     ds[var] = ds[var].rename({old_vert_coord_name: f"nz_{segment_name}_{base_var}"})
 
     ## Replace the old depth coordinates with incremental integers
-    regridding_logger.info("Replacing old depth coordinates with incremental integers")
+    regridding_logger.debug("Replacing old depth coordinates with incremental integers")
     ds[f"nz_{segment_name}_{base_var}"] = np.arange(
         ds[f"nz_{segment_name}_{base_var}"].size
     )
@@ -559,7 +560,7 @@ def mask_dataset(
     """
     ## Add Boundary Mask ##
     if bathymetry is not None:
-        regridding_logger.info(
+        regridding_logger.debug(
             "Masking to bathymetry. If you don't want this, set bathymetry_path to None in the segment class."
         )
         mask = get_boundary_mask(
@@ -625,7 +626,7 @@ def generate_encoding(
 
         (dict): The encoding dictionary
     """
-    regridding_logger.info("Generating encoding dictionary")
+    regridding_logger.debug("Generating encoding dictionary")
     for var in ds:
         if "_segment_" in var and not "nz" in var:
             encoding_dict[var] = {

--- a/regional_mom6/rotation.py
+++ b/regional_mom6/rotation.py
@@ -1,7 +1,8 @@
+import logging
 from regional_mom6 import utils
 from regional_mom6.regridding import get_hgrid_arakawa_c_points, coords
 
-rotation_logger = utils.setup_logger(__name__, set_handler=False)
+rotation_logger = logging.getLogger(__name__)
 # An Enum is like a dropdown selection for a menu, it essentially limits the type of input parameters.
 # It comes with additional complexity, which of course is always a challenge.
 from enum import Enum

--- a/regional_mom6/utils.py
+++ b/regional_mom6/utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import logging
-import sys
 import xarray as xr
 from regional_mom6 import regridding as rgd
 from pathlib import Path
@@ -78,7 +77,7 @@ def try_pint_convert(da, target_units, var_name=None, debug=False):
             )
             return da_converted
         else:
-            utils_logger.info(f"Units for {var_name} did not need to be converted")
+            utils_logger.debug(f"Units for {var_name} did not need to be converted")
 
     except Exception as e:
         # If any error occurs (bad units, missing Pint, etc.), fall back gracefully
@@ -211,29 +210,6 @@ def ep2ap(SEMA, ECC, INC, PHA):
     return ua, va, up, vp
 
 
-def setup_logger(
-    name: str, set_handler=False, log_level=logging.INFO
-) -> logging.Logger:
-    """
-    Setup general configuration for a logger.
-    """
-
-    logger = logging.getLogger(name)
-    logger.setLevel(log_level)
-    if set_handler and not logger.hasHandlers():
-        # Create a handler to print to stdout (Jupyter captures stdout)
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(log_level)
-
-        # Create a formatter (optional)
-        formatter = logging.Formatter("%(name)s.%(funcName)s:%(levelname)s:%(message)s")
-        handler.setFormatter(formatter)
-
-        # Add the handler to the logger
-        logger.addHandler(handler)
-    return logger
-
-
 def rotate_complex(u, v, radian_angle):
     """
     Rotate velocities counter-clockwise by angle ``radian_angle`` (in radians) using complex number math (Same as :func:`rotate`.)
@@ -347,4 +323,4 @@ def get_edge(ds, edge, x_name=None, y_name=None):
         return ds.isel({x_name: 0})
 
 
-utils_logger = setup_logger(__name__, set_handler=False)
+utils_logger = logging.getLogger(__name__)

--- a/regional_mom6/validate.py
+++ b/regional_mom6/validate.py
@@ -8,9 +8,9 @@ from pathlib import Path
 import xarray as xr
 import numpy as np
 import re
-from .utils import setup_logger
+import logging
 
-logger = setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_file(file):


### PR DESCRIPTION
Closes #262

- All `logging.info` calls in `regridding.py` (and one in `utils.py`) that describe internal processing steps are downgraded to `logging.debug`
- `setup_logger` in `utils.py` was a thin wrapper around `logging.getLogger` with dead handler/level logic; replaced with `logging.getLogger(__name__)` at each call site
- Recommendation from Claude: Added `NullHandler` to the package-level logger in `__init__.py` so regional-mom6 behaves as a library and does not emit output unless the caller configures logging (so things the user should see should be print statements)