### PR TITLE
Don't reuse regridding weights by default; expose regridders on segment

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2075,6 +2075,8 @@ class segment:
             self.bathymetry = None
         self.segment_name = segment_name
         self.repeat_year_forcing = repeat_year_forcing
+        self.regridders = None
+        self.tidal_regridders = None
 
     def regrid_velocity_tracers(
         self,
@@ -2086,6 +2088,7 @@ class segment:
         time_units="days",
         calendar="gregorian",
         fill_method=rgd.fill_missing_data,
+        regridders=None,
     ):
         """
         Cut out and interpolate the velocities and tracers.
@@ -2101,6 +2104,11 @@ class segment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
+            regridders (dict, optional): Pre-built regridders with keys ``"tracers"``, ``"u"``, ``"v"``.
+                If provided, regridder creation is skipped entirely — useful when calling this method
+                multiple times for different time windows on the same grid (pass ``seg.regridders``
+                from a prior call). Default ``None`` — regridders are built and saved to
+                ``self.regridders``.
 
         """
         reprocessed_var_map = apply_arakawa_grid_mapping(
@@ -2122,14 +2130,16 @@ class segment:
         for dc in dc_list:
             rawseg[dc] = try_pint_convert(rawseg[dc], "m", dc)
 
-        regridders = create_vt_regridders(
-            reprocessed_var_map,
-            rawseg,
-            coords,
-            Path(self.outfolder),
-            regridding_method,
-            self.orientation,
-        )
+        if regridders is None:
+            regridders = create_vt_regridders(
+                reprocessed_var_map,
+                rawseg,
+                coords,
+                Path(self.outfolder),
+                regridding_method,
+                self.orientation,
+            )
+        self.regridders = regridders
 
         u_regridded = regridders["u"](
             rawseg[reprocessed_var_map["u_var_name"]].rename(
@@ -2358,6 +2368,7 @@ class segment:
         rotational_method=rot.RotationMethod.EXPAND_GRID,
         regridding_method="bilinear",
         fill_method=rgd.fill_missing_data,
+        regridders=None,
     ):
         """
         Regrids and interpolates the tidal data for MOM6. Steps include:
@@ -2384,6 +2395,10 @@ class segment:
                 The default method, ``EXPAND_GRID``, works even with non-rotated grids.
             regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
+            regridders (dict, optional): Pre-built regridders with keys ``"elev"``, ``"u"``, ``"v"``.
+                If provided, regridder creation is skipped entirely — useful when calling this method
+                multiple times on the same grid (pass ``seg.tidal_regridders`` from a prior call).
+                Default ``None`` — regridders are built and saved to ``self.tidal_regridders``.
 
         Returns:
             netCDF files: Regridded tidal velocity and elevation files in 'inputdir/forcing'
@@ -2406,15 +2421,31 @@ class segment:
         # Establish Coords
         coords = rgd.coords(self.hgrid, self.orientation, self.segment_name)
 
+        if regridders is None:
+            regridders = {
+                "elev": rgd.create_regridder(
+                    tpxo_h[["lon", "lat", "hRe"]],
+                    coords,
+                    self.outfolder / "weights" / f"bilinear_tidal_elev_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+                "u": rgd.create_regridder(
+                    tpxo_u[["lon", "lat", "uRe"]],
+                    coords,
+                    self.outfolder / "weights" / f"bilinear_tidal_u_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+                "v": rgd.create_regridder(
+                    tpxo_v[["lon", "lat", "vRe"]],
+                    coords,
+                    self.outfolder / "weights" / f"bilinear_tidal_v_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+            }
+        self.tidal_regridders = regridders
+        regrid = regridders["elev"]
+
         ########## Tidal Elevation: Horizontally interpolate elevation components ############
-        regrid = rgd.create_regridder(
-            tpxo_h[["lon", "lat", "hRe"]],
-            coords,
-            Path(
-                self.outfolder / "forcing" / f"regrid_{self.segment_name}_tidal_elev.nc"
-            ),
-            method=regridding_method,
-        )
 
         redest = regrid(tpxo_h[["lon", "lat", "hRe"]])
         imdest = regrid(tpxo_h[["lon", "lat", "hIm"]])
@@ -2460,12 +2491,8 @@ class segment:
 
         ########### Regrid Tidal Velocity ######################
 
-        regrid_u = rgd.create_regridder(
-            tpxo_u[["lon", "lat", "uRe"]], coords, method=regridding_method
-        )
-        regrid_v = rgd.create_regridder(
-            tpxo_v[["lon", "lat", "vRe"]], coords, method=regridding_method
-        )
+        regrid_u = regridders["u"]
+        regrid_v = regridders["v"]
 
         # Interpolate each real and imaginary parts to self.
         uredest = regrid_u(tpxo_u[["lon", "lat", "uRe"]])["uRe"]

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2426,19 +2426,25 @@ class segment:
                 "elev": rgd.create_regridder(
                     tpxo_h[["lon", "lat", "hRe"]],
                     coords,
-                    self.outfolder / "weights" / f"bilinear_tidal_elev_weights_{self.segment_name}.nc",
+                    self.outfolder
+                    / "weights"
+                    / f"bilinear_tidal_elev_weights_{self.segment_name}.nc",
                     method=regridding_method,
                 ),
                 "u": rgd.create_regridder(
                     tpxo_u[["lon", "lat", "uRe"]],
                     coords,
-                    self.outfolder / "weights" / f"bilinear_tidal_u_weights_{self.segment_name}.nc",
+                    self.outfolder
+                    / "weights"
+                    / f"bilinear_tidal_u_weights_{self.segment_name}.nc",
                     method=regridding_method,
                 ),
                 "v": rgd.create_regridder(
                     tpxo_v[["lon", "lat", "vRe"]],
                     coords,
-                    self.outfolder / "weights" / f"bilinear_tidal_v_weights_{self.segment_name}.nc",
+                    self.outfolder
+                    / "weights"
+                    / f"bilinear_tidal_v_weights_{self.segment_name}.nc",
                     method=regridding_method,
                 ),
             }

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -213,6 +213,7 @@ def create_regridder(
     method: str = "bilinear",
     locstream_out: bool = True,
     periodic: bool = False,
+    reuse_weights: bool = False,
 ) -> xe.Regridder:
     """
     Basic regridder for any forcing variables. This is essentially a wrapper for
@@ -225,25 +226,31 @@ def create_regridder(
     output_grid : xr.Dataset
         The dataset of the output grid. This is the boundary of the ``hgrid``
     outfile : Path, optional
-        The path to the output file for weights; default: `None`
+        The path to save regridding weights; default: ``None``. Weights are always
+        written when a path is provided, even if ``reuse_weights=False``.
     method : str, optional
         The regridding method; default: ``"bilinear"``
     locstream_out : bool, optional
         Whether to output the locstream; default: ``True``
     periodic : bool, optional
         Whether the grid is periodic; default: ``False``
+    reuse_weights : bool, optional
+        If ``True`` and ``outfile`` exists on disk, load weights instead of
+        recomputing them. Default ``False`` — always recompute so that stale
+        weights from a previous grid do not silently produce wrong results.
+        Set to ``True`` only when you are certain the grid has not changed,
+        e.g. when reusing a :class:`segment` regridder across multiple time steps.
 
     Returns
     -------
     xe.Regridder
         The regridding object
     """
-    regridding_logger.info("Creating Regridder")
+    regridding_logger.debug("Creating Regridder")
 
-    weights_exist = bool(outfile) and isfile(outfile)
-    if weights_exist:
+    if reuse_weights and bool(outfile) and isfile(outfile):
         regridding_logger.warning(
-            f"Using existing weights file at {outfile} to save computing time. Delete weights file to regenerate weights."
+            f"Reusing existing weights file at {outfile}. Delete it if the grid has changed."
         )
     regridder = xe.Regridder(
         forcing_variables,
@@ -252,7 +259,7 @@ def create_regridder(
         locstream_out=locstream_out,
         periodic=periodic,
         filename=outfile,
-        reuse_weights=weights_exist,
+        reuse_weights=reuse_weights,
         unmapped_to_nan=True,
     )
 


### PR DESCRIPTION
Closes #297
Closes #296

Changes:

- `create_regridder` gains an explicit `reuse_weights=False` parameter. Previously weights were silently reused whenever the weights file already existed on disk, causing wrong results if the grid was regenerated. Now weights are always recomputed unless the caller explicitly opts in with `reuse_weights=True`.
- `segment.regrid_velocity_tracers` and `segment.regrid_tides` both accept an optional `regridders=` kwarg. When omitted, regridders are created as before and cached on `self.regridders` / `self.tidal_regridders`. Power users (e.g. CrocoDash running multiple time windows on the same grid) can pass those back in on subsequent calls to skip recomputation.
- Tidal u/v regridders now write weights files to `weights/` (previously nothing was written to disk for these).