### PR TITLE
Make grid-generation args optional when Grid/VGrid objects are passed

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -390,11 +390,8 @@ class experiment:
             # accessed. A rotation-angle discrepancy here is only warned about (not
             # raised), so construction can still succeed and the user has a live
             # `experiment` to call `recalculate_rotation_angle()` on afterward.
-            try:
-                hgrid = self.hgrid
-            except ValueError as e:
-                warnings.warn(str(e))
-                hgrid = self.m6f_hgrid.supergrid.to_ds()
+            hgrid = self.hgrid
+            hgrid = self.m6f_hgrid.supergrid.to_ds()
             self.longitude_extent = (float(hgrid.x.min()), float(hgrid.x.max()))
             self.latitude_extent = (float(hgrid.y.min()), float(hgrid.y.max()))
         else:
@@ -484,7 +481,7 @@ class experiment:
             np.nanmax(np.abs(supergrid.angle_dx - expected_angle_dx))
         )
         if max_discrepancy > ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES:
-            raise ValueError(
+            warnings.warn(
                 f"The `angle_dx` stored in {source} disagrees with the angle MOM6's "
                 f"expanded-supergrid method computes from the grid's x/y coordinates "
                 f"by up to {max_discrepancy:.2f} degrees (threshold: "

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -223,27 +223,36 @@ class experiment:
     Arguments:
         date_range (Tuple[str]): Start and end dates of the boundary forcing window. For
             example: ``("2003-01-01", "2003-01-31")``.
-        resolution (float): Lateral resolution of the domain (in degrees).
-        number_vertical_layers (int): Number of vertical layers.
-        layer_thickness_ratio (float): Ratio of largest to smallest layer thickness;
-            used as input in :func:`~hyperbolictan_thickness_profile`.
-        depth (float): Depth of the domain.
         mom_run_dir (str): Path of the MOM6 control directory.
         mom_input_dir (str): Path of the MOM6 input directory, to receive the forcing files.
+        resolution (float, optional): Lateral resolution of the domain (in degrees). Required
+            only when ``hgrid_type`` doesn't already provide a ``Grid`` object (i.e., you need
+            one to be generated from ``longitude_extent``/``latitude_extent``).
+        number_vertical_layers (int, optional): Number of vertical layers. Required only when
+            ``vgrid_type`` doesn't already provide a ``VGrid`` object.
+        layer_thickness_ratio (float, optional): Ratio of largest to smallest layer thickness;
+            used as input in :func:`~hyperbolictan_thickness_profile`. Required only when
+            ``vgrid_type`` doesn't already provide a ``VGrid`` object.
+        depth (float, optional): Depth of the domain. Required only when ``vgrid_type`` doesn't
+            already provide a ``VGrid`` object.
         fre_tools_dir (str): Path of GFDL's FRE tools (https://github.com/NOAA-GFDL/FRE-NCtools)
             binaries.
-        longitude_extent (Tuple[float]): Extent of the region in longitude (in degrees). For
-            example: ``(40.5, 50.0)``.
-        latitude_extent (Tuple[float]): Extent of the region in latitude (in degrees). For
-            example: ``(-20.0, 30.0)``.
+        longitude_extent (Tuple[float], optional): Extent of the region in longitude (in degrees). For
+            example: ``(40.5, 50.0)``. Required only when ``hgrid_type`` doesn't already provide a
+            ``Grid`` object.
+        latitude_extent (Tuple[float], optional): Extent of the region in latitude (in degrees). For
+            example: ``(-20.0, 30.0)``. Required only when ``hgrid_type`` doesn't already provide a
+            ``Grid`` object.
         hgrid_type (str or Grid): Type of horizontal grid to generate. Currently, only ``'even_spacing'`` is supported.
             Setting this argument to ``'from_file'`` lazily reads ``hgrid.nc`` from ``mom_input_dir`` the first time
             the ``hgrid`` property is accessed. You can also pass a mom6_forge ``Grid`` object directly, in which case
-            ``hgrid`` is derived from it instead of touching disk.
+            ``hgrid`` is derived from it instead of touching disk, and ``resolution``/``longitude_extent``/
+            ``latitude_extent`` are not required.
         vgrid_type (str or VGrid): Type of vertical grid to generate. Currently, only ``'hyperbolic_tangent'`` is
             supported. Setting this argument to ``'from_file'`` lazily reads ``vgrid.nc`` from ``mom_input_dir`` the
             first time the ``vgrid`` property is accessed. You can also pass a mom6_forge ``VGrid`` object directly, in
-            which case ``vgrid`` is derived from it instead of touching disk.
+            which case ``vgrid`` is derived from it instead of touching disk, and ``number_vertical_layers``/
+            ``layer_thickness_ratio``/``depth`` are not required.
         repeat_year_forcing (bool): When ``True`` the experiment runs with
             repeat-year forcing. When ``False`` (default) then inter-annual forcing is used.
         minimum_depth (int): The minimum depth in meters of a grid cell allowed before it is masked out and treated as land.
@@ -341,12 +350,12 @@ class experiment:
         self,
         *,
         date_range,
-        resolution,
-        number_vertical_layers,
-        layer_thickness_ratio,
-        depth,
         mom_run_dir,
         mom_input_dir,
+        resolution=None,
+        number_vertical_layers=None,
+        layer_thickness_ratio=None,
+        depth=None,
         fre_tools_dir=None,
         longitude_extent=None,
         latitude_extent=None,
@@ -427,6 +436,15 @@ class experiment:
                 float(self.hgrid.y.max()),
             )
         else:
+            assert (
+                resolution is not None
+                and longitude_extent is not None
+                and latitude_extent is not None
+            ), (
+                "`resolution`, `longitude_extent`, and `latitude_extent` are required "
+                "to generate an hgrid; pass a mom6_forge `Grid` object via `hgrid_type` "
+                "instead if you don't want to specify them."
+            )
             self.longitude_extent = tuple(longitude_extent)
             self.latitude_extent = tuple(latitude_extent)
             self._make_hgrid()  # sets `self.m6f_hgrid`; `self.hgrid` derives from it
@@ -438,6 +456,15 @@ class experiment:
             # it's accessed.
             pass
         else:
+            assert (
+                number_vertical_layers is not None
+                and layer_thickness_ratio is not None
+                and depth is not None
+            ), (
+                "`number_vertical_layers`, `layer_thickness_ratio`, and `depth` are "
+                "required to generate a vgrid; pass a mom6_forge `VGrid` object via "
+                "`vgrid_type` instead if you don't want to specify them."
+            )
             self._make_vgrid()  # sets `self.m6f_vgrid`; `self.vgrid` derives from it
 
         self.segments = {}

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -14,7 +14,6 @@ import importlib.resources
 import pandas as pd
 from pathlib import Path
 import json
-from enum import Enum
 from ruamel.yaml import YAML
 from regional_mom6 import MOM_parameter_tools as mpt
 from regional_mom6 import regridding as rgd
@@ -28,7 +27,6 @@ from regional_mom6.utils import (
     rotate,
     find_files_by_pattern,
     try_pint_convert,
-    is_rectilinear_hgrid,
 )
 from mom6_forge._supergrid import SupergridBase
 from mom6_forge.utils import longitude_slicer
@@ -43,73 +41,36 @@ __all__ = [
     "experiment",
     "segment",
     "get_glorys_data",
-    "RotationMethod",
-    "get_rotation_angle",
 ]
 
 
-class RotationMethod(Enum):
-    """Prescribes the rotational method used in boundary conditions when the grid
-    does not have coordinates along lines of constant longitude-latitude.
+def _get_angle_dx(hgrid: xr.Dataset, orientation=None) -> xr.DataArray:
+    """Return the MOM6-consistent ``angle_dx`` rotation angle (degrees) for the hgrid,
+    or a boundary slice of it.
 
-    Attributes:
-        EXPAND_GRID (int): Finds angles at q/u/v points by expanding the hgrid by one
-            row/column, replicating exactly what MOM6 does.
-        GIVEN_ANGLE (int): Expects a pre-given angle called ``angle_dx``.
-        NO_ROTATION (int): Grid is along lines of constant latitude-longitude; no rotation required.
-    """
-
-    EXPAND_GRID = 1
-    GIVEN_ANGLE = 2
-    NO_ROTATION = 3
-
-
-def get_rotation_angle(
-    rotational_method: RotationMethod, hgrid: xr.Dataset, orientation=None
-) -> xr.DataArray:
-    """Return the rotation angle (degrees) for the hgrid or a boundary slice of it.
+    ``angle_dx`` is computed by mom6_forge (via the expanded-supergrid method) at grid
+    construction time and is always present on ``experiment.hgrid``; see
+    :meth:`~experiment.recalculate_rotation_angle` if it ever needs to be refreshed.
 
     Parameters
     ----------
-    rotational_method : RotationMethod
     hgrid : xr.Dataset
     orientation : str, optional
         If given (e.g. ``"north"``), return only the boundary slice.
     """
-    boundary = orientation is not None
+    if orientation is not None:
+        return rgd.coords(
+            hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
+        )["angle"]
+    return hgrid["angle_dx"]
 
-    if rotational_method == RotationMethod.NO_ROTATION:
-        if not is_rectilinear_hgrid(hgrid):
-            raise ValueError("NO_ROTATION method only works with rectilinear grids")
-        angles = xr.zeros_like(hgrid.x)
-        if boundary:
-            hgrid["zero_angle"] = angles
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="zero_angle"
-            )["angle"]
-        return angles
 
-    elif rotational_method == RotationMethod.GIVEN_ANGLE:
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
-            )["angle"]
-        return hgrid["angle_dx"]
-
-    elif rotational_method == RotationMethod.EXPAND_GRID:
-        hgrid["angle_dx_rm6"] = xr.DataArray(
-            SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
-                hgrid.x.values, hgrid.y.values
-            ),
-            dims=hgrid.x.dims,
-        )
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx_rm6"
-            )["angle"]
-        return hgrid["angle_dx_rm6"]
-
-    raise ValueError("Invalid rotational method")
+# Maximum tolerated disagreement (in degrees) between an hgrid.nc file's stored
+# `angle_dx` and the angle MOM6's expanded-supergrid method computes from the same
+# grid's x/y coordinates, before `experiment.hgrid` refuses to use it. A large
+# disagreement usually means the file's `angle_dx` came from a different tool or
+# rotation convention than mom6_forge/MOM6 expect.
+ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES = 5.0
 
 
 # If the array is pint possible, ensure we have the right units for main fields (eta, u, v, temp),
@@ -425,16 +386,17 @@ class experiment:
                 float(self.hgrid.y.max()),
             )
         elif hgrid_type == "from_file":
-            # `self.hgrid` lazily reads `mom_input_dir/hgrid.nc` the first time
-            # it's accessed.
-            self.longitude_extent = (
-                float(self.hgrid.x.min()),
-                float(self.hgrid.x.max()),
-            )
-            self.latitude_extent = (
-                float(self.hgrid.y.min()),
-                float(self.hgrid.y.max()),
-            )
+            # `self.hgrid` lazily reads `mom_input_dir/hgrid.nc` the first time it's
+            # accessed. A rotation-angle discrepancy here is only warned about (not
+            # raised), so construction can still succeed and the user has a live
+            # `experiment` to call `recalculate_rotation_angle()` on afterward.
+            try:
+                hgrid = self.hgrid
+            except ValueError as e:
+                warnings.warn(str(e))
+                hgrid = self.m6f_hgrid.supergrid.to_ds()
+            self.longitude_extent = (float(hgrid.x.min()), float(hgrid.x.max()))
+            self.latitude_extent = (float(hgrid.y.min()), float(hgrid.y.max()))
         else:
             assert (
                 resolution is not None
@@ -492,7 +454,10 @@ class experiment:
 
         If ``m6f_hgrid`` hasn't been supplied yet -- passed in directly via
         ``hgrid_type``, or generated by ``_make_hgrid`` -- it's lazily built from
-        ``hgrid.nc`` in ``mom_input_dir`` the first time this property is accessed.
+        ``hgrid.nc`` in ``mom_input_dir`` the first time this property is accessed. On
+        that first load, the file's ``angle_dx`` is checked against the angle MOM6's
+        expanded-supergrid method would compute from the grid's ``x``/``y``
+        coordinates; see :meth:`recalculate_rotation_angle`.
         """
         if self.m6f_hgrid is None:
             hgrid_path = self.mom_input_dir / "hgrid.nc"
@@ -503,7 +468,49 @@ class experiment:
                     "object via `hgrid_type`."
                 )
             self.m6f_hgrid = Grid.from_supergrid(hgrid_path)
+            self._validate_hgrid_rotation_angle(source=hgrid_path)
         return self.m6f_hgrid.supergrid.to_ds()
+
+    def _validate_hgrid_rotation_angle(self, source):
+        """Compare the loaded hgrid's stored ``angle_dx`` against the angle MOM6's
+        expanded-supergrid method computes from its ``x``/``y`` coordinates, and raise
+        if they disagree by more than :data:`ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES`.
+        """
+        supergrid = self.m6f_hgrid.supergrid
+        expected_angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
+            supergrid.x, supergrid.y
+        )
+        max_discrepancy = float(
+            np.nanmax(np.abs(supergrid.angle_dx - expected_angle_dx))
+        )
+        if max_discrepancy > ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES:
+            raise ValueError(
+                f"The `angle_dx` stored in {source} disagrees with the angle MOM6's "
+                f"expanded-supergrid method computes from the grid's x/y coordinates "
+                f"by up to {max_discrepancy:.2f} degrees (threshold: "
+                f"{ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES} degrees). This usually means "
+                "the hgrid.nc came from a different tool or rotation convention. If the "
+                "MOM6-consistent angle is what you actually want, call "
+                "`recalculate_rotation_angle()` to overwrite it."
+            )
+
+    def recalculate_rotation_angle(self):
+        """Recompute ``angle_dx`` for the current hgrid using MOM6's
+        expanded-supergrid method, overwriting whatever is currently stored.
+
+        Call this after hand-editing the hgrid's coordinates (e.g. via
+        ``TopoEditor``/manual rotation), or if :attr:`hgrid` raised a discrepancy
+        error and the MOM6-consistent angle is what you want.
+        """
+        if self.m6f_hgrid is None:
+            try:
+                self.hgrid  # lazily load; a discrepancy error here is exactly what we're about to fix
+            except ValueError:
+                pass
+        supergrid = self.m6f_hgrid.supergrid
+        supergrid.angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
+            supergrid.x, supergrid.y
+        )
 
     @property
     def vgrid(self):
@@ -791,7 +798,6 @@ class experiment:
         varnames,
         arakawa_grid="A",
         vcoord_type="height",
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
     ):
         """
@@ -806,7 +812,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             vcoord_type (Optional[str]): The type of vertical coordinate used in the forcing files.
                 Either ``'height'`` or ``'thickness'``.
-            rotational_method (Optional[RotationMethod]): The method used to rotate the velocities.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
         """
         if regridding_method is None:
@@ -992,9 +997,7 @@ class experiment:
         rotated_u, rotated_v = rotate(
             regridded_u,
             regridded_v,
-            radian_angle=np.radians(
-                get_rotation_angle(rotational_method, hgrid).values
-            ),
+            radian_angle=np.radians(_get_angle_dx(hgrid).values),
         )
 
         # Slice the velocites to the u and v grid.
@@ -1261,7 +1264,6 @@ class experiment:
         bgc_tracer_names: dict = None,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1282,8 +1284,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
                 boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is ``EXPAND_GRID``.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
         """
@@ -1330,7 +1330,6 @@ class experiment:
                 ),  # A number to identify the boundary; indexes from 1
                 arakawa_grid=arakawa_grid,
                 bathymetry_path=bathymetry_path,
-                rotational_method=rotational_method,
                 regridding_method=regridding_method,
                 fill_method=fill_method,
             )
@@ -1380,7 +1379,6 @@ class experiment:
         segment_number,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1402,8 +1400,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
                 the boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
 
@@ -1434,7 +1430,6 @@ class experiment:
             infile=path_to_bc,  # location of raw boundary
             varnames=varnames,
             arakawa_grid=arakawa_grid,
-            rotational_method=rotational_method,
             regridding_method=regridding_method,
             fill_method=fill_method,
         )
@@ -1448,7 +1443,6 @@ class experiment:
         tpxo_velocity_filepath,
         tidal_constituents=None,
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1461,7 +1455,6 @@ class experiment:
             tpxo_velocity_filepath: Filepath to the TPXO velocity product. Generally of the form ``u_tidalversion.nc``
             tidal_constituents: List of tidal constituents to include in the regridding. Default is set in the experiment constructor (See :class:`~Experiment`)
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case the boundary condition is not masked
-            rotational_method (str): Method to use for rotating the tidal velocities. Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
 
@@ -1556,7 +1549,6 @@ class experiment:
                 tpxo_u,
                 tpxo_h,
                 times,
-                rotational_method=rotational_method,
                 regridding_method=regridding_method,
             )
             print("Done")
@@ -2242,7 +2234,6 @@ class segment:
         infile,
         varnames: dict,
         arakawa_grid="A",
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method="bilinear",
         time_units="days",
         calendar="gregorian",
@@ -2253,7 +2244,6 @@ class segment:
         Cut out and interpolate the velocities and tracers.
 
         Arguments:
-            rotational_method (RotationMethod): The method to use for rotation of the velocities. Currently, the default method, ``EXPAND_GRID``, works even with non-rotated grids.
             infile (Union[str, Path]): Path to the raw, unprocessed boundary segment.
             varnames (Dict[str, str]): Mapping between the variable/dimension names and
             standard naming convention of this pipeline, e.g., ``{"xq": "longitude,
@@ -2332,9 +2322,7 @@ class segment:
             u_regridded,
             v_regridded,
             radian_angle=np.radians(
-                get_rotation_angle(
-                    rotational_method, self.hgrid, orientation=self.orientation
-                ).values
+                _get_angle_dx(self.hgrid, orientation=self.orientation).values
             ),
         )
 
@@ -2524,7 +2512,6 @@ class segment:
         tpxo_u,
         tpxo_h,
         times,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method="bilinear",
         fill_method=rgd.fill_missing_data,
         regridders=None,
@@ -2550,8 +2537,6 @@ class segment:
             infile_td (str): Raw tidal file/directory.
             tpxo_v, tpxo_u, tpxo_h (xarray.Dataset): Specific adjusted for MOM6 tpxo datasets (Adjusted with :func:`~experiment.setup_boundary_tides`)
             times (pd.DateRange): The start date of our model period.
-            rotational_method (RotationMethod): The method to use for rotation of the velocities.
-                The default method, ``EXPAND_GRID``, works even with non-rotated grids.
             regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
             regridders (dict, optional): Pre-built regridders with keys ``"elev"``, ``"u"``, ``"v"``.
@@ -2691,9 +2676,7 @@ class segment:
 
         # Rotate
         INC -= np.radians(
-            get_rotation_angle(
-                rotational_method, self.hgrid, orientation=self.orientation
-            ).data[np.newaxis, :]
+            _get_angle_dx(self.hgrid, orientation=self.orientation).data[np.newaxis, :]
         )
 
         ua, va, up, vp = ep2ap(SEMA, ECC, INC, PHA)

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -502,11 +502,7 @@ class experiment:
         ``TopoEditor``/manual rotation), or if :attr:`hgrid` raised a discrepancy
         error and the MOM6-consistent angle is what you want.
         """
-        if self.m6f_hgrid is None:
-            try:
-                self.hgrid  # lazily load; a discrepancy error here is exactly what we're about to fix
-            except ValueError:
-                pass
+        assert self.hgrid is not None, "No hgrid available"
         supergrid = self.m6f_hgrid.supergrid
         supergrid.angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
             supergrid.x, supergrid.y

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 import xarray as xr
 import numpy as np
 from mom6_forge.grid import *
+from mom6_forge.vgrid import VGrid
+from mom6_forge.topo import Topo
 import regional_mom6 as rmom6
 from regional_mom6 import experiment
 
@@ -79,6 +81,23 @@ def get_curvilinear_hgrid():
         pytest.skip(
             f"Required file 'hgrid.nc' not found in {DOCKER_FILE_PATH} or {LOCAL_FILE_PATH}"
         )
+
+
+@pytest.fixture
+def grid():
+    return Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
+
+
+@pytest.fixture
+def vgrid():
+    return VGrid.hyperbolic(5, 1000, 1)
+
+
+@pytest.fixture
+def flat_topo(grid):
+    topo = Topo(grid, min_depth=4, git=False)
+    topo.set_flat(1000.0)
+    return topo
 
 
 @pytest.fixture

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 from regional_mom6 import experiment
-from mom6_forge.grid import Grid
-from mom6_forge.vgrid import VGrid
 import xarray as xr
 import xesmf as xe
 import dask
@@ -496,13 +494,12 @@ def test_reformat_bgc_tracers_into_files(tmp_path):
         ), "physical tracer should not be in BGC file"
 
 
-def test_experiment_from_grid_and_vgrid_objects_without_scalar_args(tmp_path):
+def test_experiment_from_grid_and_vgrid_objects_without_scalar_args(
+    tmp_path, grid, vgrid
+):
     """Passing Grid/VGrid objects directly via hgrid_type/vgrid_type should not require
     resolution, longitude_extent, latitude_extent, number_vertical_layers,
     layer_thickness_ratio, or depth."""
-    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
-    vgrid = VGrid.hyperbolic(5, 1000, 1)
-
     expt = experiment(
         date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
         mom_run_dir=tmp_path / "rundir",
@@ -545,10 +542,9 @@ def test_experiment_requires_vgrid_scalars_when_no_vgrid_object(tmp_path):
         )
 
 
-def _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees):
+def _write_hgrid_with_angle_offset(tmp_path, grid, angle_offset_degrees):
     """Build a small hgrid via mom6_forge, inject an `angle_dx` discrepancy, and write
     it to `tmp_path/inputdir/hgrid.nc`. Returns the input dir."""
-    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
     ds = grid.supergrid.to_ds()
     ds["angle_dx"] = ds["angle_dx"] + angle_offset_degrees
     input_dir = tmp_path / "inputdir"
@@ -557,11 +553,13 @@ def _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees):
     return input_dir
 
 
-def test_hgrid_property_raises_on_stale_angle_dx_after_construction(tmp_path):
+def test_hgrid_property_raises_on_stale_angle_dx_after_construction(tmp_path, grid):
     """A large angle_dx discrepancy discovered on a *lazy* hgrid.nc load (i.e. not
     during __init__ itself) should hard-error, pointing at recalculate_rotation_angle.
     """
-    input_dir = _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees=45.0)
+    input_dir = _write_hgrid_with_angle_offset(
+        tmp_path, grid, angle_offset_degrees=45.0
+    )
 
     expt = experiment.create_empty()
     expt.mom_input_dir = input_dir
@@ -570,12 +568,15 @@ def test_hgrid_property_raises_on_stale_angle_dx_after_construction(tmp_path):
         expt.hgrid
 
 
-def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(tmp_path):
+def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(
+    tmp_path, grid, vgrid
+):
     """The same discrepancy, discovered during __init__ (hgrid_type='from_file'),
     should only warn -- construction must still succeed so the user has an experiment
     to call recalculate_rotation_angle() on."""
-    input_dir = _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees=45.0)
-    vgrid = VGrid.hyperbolic(5, 1000, 1)
+    input_dir = _write_hgrid_with_angle_offset(
+        tmp_path, grid, angle_offset_degrees=45.0
+    )
 
     with pytest.warns(UserWarning, match="recalculate_rotation_angle"):
         expt = experiment(
@@ -590,12 +591,9 @@ def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(tmp_path):
     assert np.allclose(expt.hgrid["angle_dx"], 0.0, atol=1e-6)
 
 
-def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path):
+def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, vgrid):
     """Calling recalculate_rotation_angle() on an already-consistent grid should
     leave angle_dx unchanged."""
-    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
-    vgrid = VGrid.hyperbolic(5, 1000, 1)
-
     expt = experiment(
         date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
         mom_run_dir=tmp_path / "rundir",

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -542,7 +542,7 @@ def test_experiment_requires_vgrid_scalars_when_no_vgrid_object(tmp_path):
         )
 
 
-def _write_hgrid_with_angle_offset(tmp_path, grid, angle_offset_degrees):
+def _write_hgrid_with_bad_angle_calc(tmp_path, grid, angle_offset_degrees):
     """Build a small hgrid via mom6_forge, inject an `angle_dx` discrepancy, and write
     it to `tmp_path/inputdir/hgrid.nc`. Returns the input dir."""
     ds = grid.supergrid.to_ds()
@@ -553,28 +553,11 @@ def _write_hgrid_with_angle_offset(tmp_path, grid, angle_offset_degrees):
     return input_dir
 
 
-def test_hgrid_property_raises_on_stale_angle_dx_after_construction(tmp_path, grid):
+def test_hgrid_property_raises_on_stale_angle_dx(tmp_path, grid, vgrid):
     """A large angle_dx discrepancy discovered on a *lazy* hgrid.nc load (i.e. not
     during __init__ itself) should hard-error, pointing at recalculate_rotation_angle.
     """
-    input_dir = _write_hgrid_with_angle_offset(
-        tmp_path, grid, angle_offset_degrees=45.0
-    )
-
-    expt = experiment.create_empty()
-    expt.mom_input_dir = input_dir
-
-    with pytest.raises(ValueError, match="recalculate_rotation_angle"):
-        expt.hgrid
-
-
-def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(
-    tmp_path, grid, vgrid
-):
-    """The same discrepancy, discovered during __init__ (hgrid_type='from_file'),
-    should only warn -- construction must still succeed so the user has an experiment
-    to call recalculate_rotation_angle() on."""
-    input_dir = _write_hgrid_with_angle_offset(
+    input_dir = _write_hgrid_with_bad_angle_calc(
         tmp_path, grid, angle_offset_degrees=45.0
     )
 
@@ -586,9 +569,6 @@ def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(
             hgrid_type="from_file",
             vgrid_type=vgrid,
         )
-
-    expt.recalculate_rotation_angle()
-    assert np.allclose(expt.hgrid["angle_dx"], 0.0, atol=1e-6)
 
 
 def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, vgrid):

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 from regional_mom6 import experiment
+from mom6_forge.grid import Grid
+from mom6_forge.vgrid import VGrid
 import xarray as xr
 import xesmf as xe
 import dask
@@ -492,3 +494,52 @@ def test_reformat_bgc_tracers_into_files(tmp_path):
         assert (
             f"temp_segment_{seg}" not in result
         ), "physical tracer should not be in BGC file"
+
+
+def test_experiment_from_grid_and_vgrid_objects_without_scalar_args(tmp_path):
+    """Passing Grid/VGrid objects directly via hgrid_type/vgrid_type should not require
+    resolution, longitude_extent, latitude_extent, number_vertical_layers,
+    layer_thickness_ratio, or depth."""
+    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
+    vgrid = VGrid.hyperbolic(5, 1000, 1)
+
+    expt = experiment(
+        date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        hgrid_type=grid,
+        vgrid_type=vgrid,
+    )
+
+    assert expt.longitude_extent == (-5.0, 5.0)
+    assert expt.latitude_extent == (0.0, 10.0)
+    assert expt.m6f_hgrid is grid
+    assert expt.m6f_vgrid is vgrid
+
+
+def test_experiment_requires_hgrid_scalars_when_no_grid_object(tmp_path):
+    """Without a Grid object, resolution/longitude_extent/latitude_extent are required
+    to generate an hgrid."""
+    with pytest.raises(AssertionError, match="resolution"):
+        experiment(
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=tmp_path / "inputdir",
+            number_vertical_layers=5,
+            layer_thickness_ratio=1,
+            depth=1000,
+        )
+
+
+def test_experiment_requires_vgrid_scalars_when_no_vgrid_object(tmp_path):
+    """Without a VGrid object, number_vertical_layers/layer_thickness_ratio/depth are
+    required to generate a vgrid."""
+    with pytest.raises(AssertionError, match="number_vertical_layers"):
+        experiment(
+            longitude_extent=[-5, 5],
+            latitude_extent=[0, 10],
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            resolution=0.1,
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=tmp_path / "inputdir",
+        )

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -543,3 +543,69 @@ def test_experiment_requires_vgrid_scalars_when_no_vgrid_object(tmp_path):
             mom_run_dir=tmp_path / "rundir",
             mom_input_dir=tmp_path / "inputdir",
         )
+
+
+def _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees):
+    """Build a small hgrid via mom6_forge, inject an `angle_dx` discrepancy, and write
+    it to `tmp_path/inputdir/hgrid.nc`. Returns the input dir."""
+    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
+    ds = grid.supergrid.to_ds()
+    ds["angle_dx"] = ds["angle_dx"] + angle_offset_degrees
+    input_dir = tmp_path / "inputdir"
+    input_dir.mkdir()
+    ds.to_netcdf(input_dir / "hgrid.nc")
+    return input_dir
+
+
+def test_hgrid_property_raises_on_stale_angle_dx_after_construction(tmp_path):
+    """A large angle_dx discrepancy discovered on a *lazy* hgrid.nc load (i.e. not
+    during __init__ itself) should hard-error, pointing at recalculate_rotation_angle.
+    """
+    input_dir = _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees=45.0)
+
+    expt = experiment.create_empty()
+    expt.mom_input_dir = input_dir
+
+    with pytest.raises(ValueError, match="recalculate_rotation_angle"):
+        expt.hgrid
+
+
+def test_experiment_init_warns_instead_of_raising_on_stale_angle_dx(tmp_path):
+    """The same discrepancy, discovered during __init__ (hgrid_type='from_file'),
+    should only warn -- construction must still succeed so the user has an experiment
+    to call recalculate_rotation_angle() on."""
+    input_dir = _write_hgrid_with_angle_offset(tmp_path, angle_offset_degrees=45.0)
+    vgrid = VGrid.hyperbolic(5, 1000, 1)
+
+    with pytest.warns(UserWarning, match="recalculate_rotation_angle"):
+        expt = experiment(
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=input_dir,
+            hgrid_type="from_file",
+            vgrid_type=vgrid,
+        )
+
+    expt.recalculate_rotation_angle()
+    assert np.allclose(expt.hgrid["angle_dx"], 0.0, atol=1e-6)
+
+
+def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path):
+    """Calling recalculate_rotation_angle() on an already-consistent grid should
+    leave angle_dx unchanged."""
+    grid = Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
+    vgrid = VGrid.hyperbolic(5, 1000, 1)
+
+    expt = experiment(
+        date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        hgrid_type=grid,
+        vgrid_type=vgrid,
+    )
+
+    before = expt.hgrid["angle_dx"].values.copy()
+    expt.recalculate_rotation_angle()
+    after = expt.hgrid["angle_dx"].values
+
+    np.testing.assert_allclose(before, after)


### PR DESCRIPTION
## Summary
- `resolution`, `number_vertical_layers`, `layer_thickness_ratio`, and `depth` were required constructor arguments on `experiment` even when `hgrid_type`/`vgrid_type` already provided a mom6_forge `Grid`/`VGrid` object directly (in which case those scalars are never used).
- They're now optional (default `None`), and asserted only in the branches that actually need them to generate a grid via `_make_hgrid`/`_make_vgrid`.
- Docstring updated to reflect the new optionality and dependency on `hgrid_type`/`vgrid_type`.
- Because of this simplification, we no longer recalculate the angle in each sub-function. It is checked in the hgrid property on from_file reads. There is an new function to recalculate the angle in experiment as well.

## Test plan
- [x] Ran full `pytest tests/` suite in the `mom6-regional-dev` env — 42 passed, 4 skipped (pre-existing skips, unrelated)
- [x] `black --check regional_mom6/` passes
- [x] Manually verified constructing an `experiment` with `Grid`/`VGrid` objects and no `resolution`/`depth`/etc. now succeeds
- [x] Manually verified the assertion fires with a clear message when neither objects nor the scalar args are provided