### PR TITLE
Move chl.py chlorophyll interpolation into regional-mom6

### DIFF
--- a/regional_mom6/chl.py
+++ b/regional_mom6/chl.py
@@ -1,0 +1,1 @@
+from mom6_forge.chl import *

--- a/regional_mom6/chl.py
+++ b/regional_mom6/chl.py
@@ -1,1 +1,252 @@
-from mom6_forge.chl import *
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
+import xarray as xr
+import numpy as np
+import xesmf as xe
+from datetime import datetime
+from pathlib import Path
+from os.path import isfile
+from mom6_forge.utils import fill_missing_data, compute_subsampling_factor
+from mom6_forge.mapping import regrid_with_subsampling
+
+
+def interpolate_and_fill_seawifs(
+    grid: Grid,
+    topo: Topo,
+    processed_seawifs_path: Path | str,
+    output_path: Path | str = None,
+):
+    """
+    Interpolate and fill SeaWiFS chlorophyll data to a model grid and save to NetCDF.
+
+    This function assumes a NO_LEAP calendar.
+
+    This function takes gridded SeaWiFS chlorophyll data, interpolates it onto a
+    super-sampled model grid, applies ocean masking, fills missing values, and writes
+    the processed data to a NetCDF file. Global attributes are added to the output
+    dataset to document provenance and authorship.
+
+    Parameters
+    ----------
+    grid : Grid
+        Model grid object containing tracer longitude and latitude arrays (`grid.tlon`, `grid.tlat`)
+        and other grid arrays (`grid.qlon`, `grid.qlat`, `grid.nx`, `grid.ny`).
+    topo : Topo
+        Topography object containing the ocean mask (`topo.tmask`).
+    processed_seawifs_path : Path or str
+        Path to the preprocessed SeaWiFS chlorophyll dataset.
+    output_path : Path or str, optional
+        Path to save the output NetCDF file. If not provided, it is created in the same
+        directory as `processed_seawifs_path` using the grid name.
+
+    Returns
+    -------
+    xarray.Dataset
+        A dataset containing the interpolated and filled chlorophyll concentration with
+        appropriate global attributes and coordinate variables.
+    """
+    if grid.name is None:
+        grid.name = "UnknownGridName"
+
+    assert (
+        grid.is_rectangular()
+    ), "This function currently only supports rectangular grids."
+    ocn_mask = topo.tmask
+    ocn_nj, ocn_ni = ocn_mask.shape
+    src_nc = xr.open_dataset(processed_seawifs_path)
+    src_data = src_nc["chlor_a"]
+    src_nj, src_ni = src_data.shape[-2], src_data.shape[-1]
+
+    src_lon = src_nc[src_data.dims[-1]]
+    src_lat = ((np.arange(src_nj) + 0.5) / src_nj - 0.5) * 180.0  # Recompute as doubles
+
+    src_x0 = int((src_lon[0] + src_lon[-1]) / 2 + 0.5) - 180.0
+    src_lon = (
+        (np.arange(src_ni) + 0.5) / src_ni
+    ) * 360.0 + src_x0  # Recompute as doubles
+
+    ny_sub, nx_sub = compute_subsampling_factor(src_nj, src_ni, ocn_nj, ocn_ni)
+
+    # Set output path
+    if output_path is None:
+        output_path = (
+            Path(processed_seawifs_path).parent
+            / f"seawifs-clim-1997-2010-{grid.name}.nc"
+        )
+    else:
+        output_path = Path(output_path)
+
+    # Generate empty dataset to fill for chlorophyll
+    fill_value = np.float32(-1.0e34)
+    chla = gen_chl_empty_dataset(
+        output_path,
+        grid.tlon[int(grid.ny / 2), :].values,
+        grid.tlat[:, int(grid.nx / 2)].values,
+        fill_value,
+    )
+    chlor_a = chla["CHL_A"]
+
+    regridder = None
+    for t in range(src_data.shape[0]):
+
+        # Build source dataset for this timestep
+        src_ds = xr.Dataset(
+            {
+                "chlor_a": xr.DataArray(
+                    src_data[t, ::-1, :].values,
+                    dims=["lat", "lon"],
+                    coords={"lat": src_lat, "lon": src_lon},
+                )
+            }
+        )
+
+        # Regrid to super-sampled sub-point grid and average back to model grid
+        q_sub, regridder = regrid_with_subsampling(
+            input_dataset=src_ds,
+            qlon=grid.qlon.values,
+            qlat=grid.qlat.values,
+            nx_sub=nx_sub,
+            ny_sub=ny_sub,
+            regridding_method="bilinear",
+            regridder=regridder,
+        )
+        q_int = q_sub["chlor_a"].mean(dim=["ny_sub", "nx_sub"]).values
+
+        # Fill any missing data
+        q = q_int * ocn_mask
+        q_nan = np.where((q == 0) | np.isnan(q), np.nan, q)
+        chlor_a[t, :] = fill_missing_data(q_nan, ocn_mask)
+
+    # Global attributes
+    chla.attrs["title"] = (
+        "Chlorophyll Concentration, OCI Algorithm, interpolated and objectively filled to "
+        + grid.name
+    )
+    chla.attrs["repository"] = (
+        "https://github.com/NCAR/SeaWIFS_MOM6 and https://github.com/NCAR/mom6_forge"
+    )
+    chla.attrs["authors"] = (
+        "Gustavo Marques (gmarques@ucar.edu) and Frank Bryan (bryan@ucar.edu)"
+    )
+    chla.attrs["date"] = datetime.now().isoformat()
+
+    # Assign variable data
+    chla["CHL_A"].data[:] = chlor_a
+    chla["LON"] = grid.tlon[0, :]
+    chla["LAT"] = grid.tlat[:, 0]
+
+    # Write to NetCDF
+    chla.to_netcdf(
+        output_path,
+        unlimited_dims=["TIME"],
+        encoding={
+            "CHL_A": {
+                "_FillValue": fill_value,
+            }
+        },
+        format="NETCDF3_64BIT",
+    )
+    print(f"Wrote interpolated and filled SeaWiFS data to:\n{output_path}")
+
+    # Clean up weights file if it exists
+    Path("bilin_weights.nc").unlink(missing_ok=True)
+
+    return chla
+
+
+def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, no_leap=True):
+    """
+    Generate an empty NetCDF dataset for SeaWiFS chlorophyll climatology and save it to disk.
+
+    This function assumes a NO_LEAP calendar.
+
+    This function creates a synthetic xarray dataset with a CHL_A variable (monthly mean chlorophyll)
+    initialized entirely with fill values. The dataset uses the provided longitude and latitude
+    arrays to define the spatial grid and includes a fixed climatological time axis.
+
+    Parameters
+    ----------
+    output_path : str or Path
+        Path to save the output NetCDF file.
+
+    lon : array-like
+        1D array of longitude values (in degrees east) defining the spatial X-axis.
+
+    lat : array-like
+        1D array of latitude values (in degrees north) defining the spatial Y-axis.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The generated empty dataset containing the CHL_A variable and coordinate metadata.
+
+    Notes
+    -----
+    - The CHL_A variable is filled with the placeholder value -1e34.
+    - The TIME dimension is fixed and marked as unlimited in the NetCDF file.
+    - TIME values represent the approximate midpoint of each month in a climatological year.
+    - This dataset structure mimics that of SeaWiFS chlorophyll climatology products and is intended
+      as a template or placeholder.
+    """
+
+    # === Coordinates ===
+
+    if no_leap:
+        time = np.array(
+            [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+        )
+    else:
+        time = np.array(
+            [15.5, 45.5, 75.5, 106, 136.5, 167, 197.5, 228.5, 259, 289.5, 320, 350.5]
+        )
+
+    # === Placeholder data for CHL_A (all fill values) ===
+    fill_value = np.float32(-1.0e34)
+    chl_a_data = np.empty((len(time), len(lat), len(lon)), dtype=np.float32)
+
+    # === xarray Dataset ===
+    ds = xr.Dataset(
+        {
+            "CHL_A": xr.DataArray(
+                chl_a_data,
+                dims=["TIME", "LAT", "LON"],
+                coords={"TIME": time, "LAT": lat, "LON": lon},
+                attrs={
+                    "long_name": "CHL_A = monthly mean",
+                    "units": "mg/m^3",
+                    "missing_value": fill_value,
+                },
+            )
+        },
+        coords={
+            "LON": xr.DataArray(
+                lon, dims="LON", attrs={"units": "degrees_east", "axis": "X"}
+            ),
+            "LAT": xr.DataArray(
+                lat, dims="LAT", attrs={"units": "degrees_north", "axis": "Y"}
+            ),
+            "TIME": xr.DataArray(
+                time,
+                dims="TIME",
+                attrs={
+                    "units": "days since 0001-01-01 00:00:00",
+                    "calendar": "NOLEAP",
+                    "modulo": " ",
+                    "axis": "T",
+                    "cartesian_axis": "T",
+                },
+            ),
+        },
+        attrs={  # Global attributes
+            "title": "SeaWiFS Chlorophyll Climatology (1997–2010)",
+            "institution": "Generated by xarray",
+            "source": "SeaWifs and NASA",
+            "history": "",
+        },
+    )
+
+    return ds
+
+
+if __name__ == "__main__":
+    interpolate_and_fill_seawifs()

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -22,6 +22,7 @@ from regional_mom6.config import Config
 from regional_mom6.grid import Grid
 from regional_mom6.vgrid import VGrid
 from regional_mom6.topo import Topo
+from regional_mom6.chl import interpolate_and_fill_seawifs
 from regional_mom6.utils import (
     ap2ep,
     ep2ap,
@@ -1617,6 +1618,33 @@ class experiment:
             self.mom_input_dir / "bathymetry.nc",
         )
         return self.m6f_bathymetry.gen_topo_ds()
+
+    def setup_chl(self, processed_seawifs_path, output_path=None):
+        """
+        Interpolate and fill the SeaWiFS chlorophyll climatology onto the experiment's grid.
+
+        Output is saved in the input directory of the experiment, unless a different
+        ``output_path`` is provided.
+
+        Arguments:
+            processed_seawifs_path (str): Path to the preprocessed SeaWiFS chlorophyll dataset.
+            output_path (Optional[str]): Path to save the output NetCDF file. Defaults to
+                ``mom_input_dir / f"seawifs-clim-1997-2010-{expt_name}.nc"``.
+        """
+        self.hgrid  # ensures `m6f_hgrid` is populated (from disk if needed)
+        self.bathymetry  # ensures `m6f_bathymetry` is populated (from disk if needed)
+
+        if output_path is None:
+            output_path = (
+                self.mom_input_dir / f"seawifs-clim-1997-2010-{self.expt_name}.nc"
+            )
+
+        return interpolate_and_fill_seawifs(
+            self.m6f_hgrid,
+            self.m6f_bathymetry,
+            processed_seawifs_path,
+            output_path=output_path,
+        )
 
     def run_FRE_tools(self):
         """

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1872,6 +1872,14 @@ class experiment:
                 0
             ].strftime("%Y, %m, %d")
 
+        # Chlorophyll shortwave penetration, if setup_chl has been run
+        chl_files = list(Path(self.mom_input_dir).glob("seawifs-clim-*.nc"))
+        if chl_files:
+            MOM_override_dict["CHL_FILE"]["value"] = f'"{chl_files[0].name}"'
+            MOM_override_dict["CHL_FROM_FILE"]["value"] = "True"
+            MOM_override_dict["VAR_PEN_SW"]["value"] = "True"
+            MOM_override_dict["PEN_SW_NBANDS"]["value"] = 3
+
         for key, val in MOM_override_dict.items():
             if isinstance(val, dict) and key != "original":
                 MOM_override_dict[key]["override"] = True

--- a/tests/test_chl.py
+++ b/tests/test_chl.py
@@ -1,76 +1,140 @@
-import socket
-
 import numpy as np
 import pytest
 import xarray as xr
-
-from regional_mom6.chl import interpolate_and_fill_seawifs
-
-SEAWIFS_PATH = "/glade/campaign/cesm/cesmdata/cseg/inputdata/ocn/mom/croc/chl/data/SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc"
+from mom6_forge.topo import Topo
 
 
-def on_cisl_machine():
-    """Return True if the current machine is a CISL machine, False otherwise."""
-    return "hpc.ucar.edu" in socket.getfqdn()
+def _make_small_seawifs_ds():
+    """Build a tiny synthetic dataset mirroring the format of the real SeaWiFS
+    climatology product (SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc), but at a very
+    coarse (5deg) global resolution so it stays small and fast to interpolate.
+    """
+    nlat, nlon, ntime = 36, 72, 12
+    dlat, dlon = 180.0 / nlat, 360.0 / nlon
 
+    # Descending latitude / ascending longitude, same convention as the real product.
+    lat = (90.0 - (np.arange(nlat) + 0.5) * dlat).astype(np.float32)
+    lon = (-180.0 + (np.arange(nlon) + 0.5) * dlon).astype(np.float32)
+    time = np.array(
+        [
+            16.0,
+            45.5,
+            75.0,
+            105.5,
+            136.0,
+            166.5,
+            197.0,
+            228.0,
+            258.5,
+            289.0,
+            319.5,
+            350.0,
+        ]
+    )
 
-requires_cisl_machine = pytest.mark.skipif(
-    not on_cisl_machine(),
-    reason="Requires the SeaWiFS chlorophyll climatology, only staged on NCAR/CISL machines",
-)
+    lat_rad = np.radians(lat)
+    lon_rad = np.radians(lon)
+    month = np.arange(ntime)
 
+    chlor_a = (
+        0.2
+        + 0.05 * np.cos(lat_rad)[None, :, None]
+        + 0.01 * np.cos(lon_rad)[None, None, :]
+        + 0.01 * np.sin(2 * np.pi * month / ntime)[:, None, None]
+    ).astype(np.float64)
 
-def add_synthetic_bathymetry(expt, tmp_path):
-    """Set up random bathymetry for `expt`, same pattern as test_expt_class.py::test_setup_bathymetry."""
-    bathymetry_file = tmp_path / "bathymetry.nc"
-    bathymetry = np.random.random((100, 100)) * (-100)
-    bathymetry = xr.DataArray(
-        bathymetry,
-        dims=["silly_lat", "silly_lon"],
-        coords={
-            "silly_lat": np.linspace(
-                expt.latitude_extent[0] - 5, expt.latitude_extent[1] + 5, 100
+    chl_attrs = {
+        "long_name": "Chlorophyll Concentration, OCI Algorithm",
+        "units": "mg m^-3",
+        "standard_name": "mass_concentration_chlorophyll_concentration_in_sea_water",
+        "valid_min": np.float32(0.001),
+        "valid_max": np.float32(100.0),
+        "display_scale": "log",
+        "display_min": np.float32(0.01),
+        "display_max": np.float32(20.0),
+    }
+
+    ds = xr.Dataset(
+        {
+            "chlor_a": xr.DataArray(
+                chlor_a, dims=["time", "lat", "lon"], attrs=chl_attrs
             ),
-            "silly_lon": np.linspace(
-                expt.longitude_extent[0] - 5, expt.longitude_extent[1] + 5, 100
+            "chlor_a_cf": xr.DataArray(
+                chlor_a.copy(), dims=["time", "lat", "lon"], attrs=chl_attrs
+            ),
+            "chlor_a_cfm": xr.DataArray(
+                chlor_a.copy(), dims=["time", "lat", "lon"], attrs=chl_attrs
+            ),
+            "ocean_mask": xr.DataArray(
+                np.ones((nlat, nlon), dtype=np.int8),
+                dims=["lat", "lon"],
+                attrs={
+                    "long_name": "Ocean Mask",
+                    "flag_values": "0, 1",
+                    "flag_meanings": "0=Land or Inland Water, 1=Ocean",
+                },
+            ),
+            "land_mask": xr.DataArray(
+                np.zeros((nlat, nlon), dtype=np.int8),
+                dims=["lat", "lon"],
+                attrs={
+                    "long_name": "Land Mask",
+                    "flag_values": "0, 1",
+                    "flag_meanings": "1=Land or Inland Water, 0=Ocean",
+                },
+            ),
+        },
+        coords={
+            "time": xr.DataArray(
+                time,
+                dims="time",
+                attrs={
+                    "long_name": "Mid-Month Day of Climatological Year",
+                    "units": "days",
+                },
+            ),
+            "lat": xr.DataArray(
+                lat,
+                dims="lat",
+                attrs={
+                    "long_name": "Latitude",
+                    "units": "degrees_north",
+                    "standard_name": "latitude",
+                    "valid_min": np.float32(-90.0),
+                    "valid_max": np.float32(90.0),
+                },
+            ),
+            "lon": xr.DataArray(
+                lon,
+                dims="lon",
+                attrs={
+                    "long_name": "Longitude",
+                    "units": "degrees_east",
+                    "standard_name": "longitude",
+                    "valid_min": np.float32(-180.0),
+                    "valid_max": np.float32(180.0),
+                },
             ),
         },
     )
-    bathymetry.name = "silly_depth"
-    bathymetry.to_netcdf(bathymetry_file)
-    bathymetry.close()
-
-    expt.setup_bathymetry(
-        bathymetry_path=str(bathymetry_file),
-        longitude_coordinate_name="silly_lon",
-        latitude_coordinate_name="silly_lat",
-        vertical_coordinate_name="silly_depth",
-    )
+    return ds
 
 
-@requires_cisl_machine
-def test_interpolate_and_fill_seawifs(simple_experiment, tmp_path):
-    """Test the creation of chl files directly via interpolate_and_fill_seawifs."""
-    add_synthetic_bathymetry(simple_experiment, tmp_path)
-
-    output_path = tmp_path / "seawifs-clim-1997-2010-chl_test_grid.nc"
-    chl_ds = interpolate_and_fill_seawifs(
-        simple_experiment.m6f_hgrid,
-        simple_experiment.m6f_bathymetry,
-        processed_seawifs_path=SEAWIFS_PATH,
-        output_path=output_path,
-    )
-
-    assert output_path.exists()
-    assert "CHL_A" in chl_ds
+@pytest.fixture
+def small_seawifs_path(tmp_path):
+    path = tmp_path / "small_seawifs.nc"
+    _make_small_seawifs_ds().to_netcdf(path)
+    return path
 
 
-@requires_cisl_machine
-def test_setup_chl(simple_experiment, tmp_path):
+def test_setup_chl(simple_experiment, small_seawifs_path):
     """Test experiment.setup_chl, which wraps interpolate_and_fill_seawifs using the experiment's own grid/bathymetry."""
-    add_synthetic_bathymetry(simple_experiment, tmp_path)
 
-    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=SEAWIFS_PATH)
+    topo = Topo(simple_experiment.m6f_hgrid, min_depth=10.0, git=False)
+    topo.set_flat(1000.0)
+    simple_experiment.m6f_bathymetry = topo
+
+    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=small_seawifs_path)
 
     expected_output = (
         simple_experiment.mom_input_dir
@@ -78,3 +142,13 @@ def test_setup_chl(simple_experiment, tmp_path):
     )
     assert expected_output.exists()
     assert "CHL_A" in chl_ds
+
+    chl_a = chl_ds["CHL_A"]
+    assert chl_a.shape == (
+        12,
+        simple_experiment.m6f_hgrid.ny,
+        simple_experiment.m6f_hgrid.nx,
+    )
+    assert np.all(np.isfinite(chl_a.values))
+    assert np.all(chl_a.values > 0.0)
+    assert np.all(chl_a.values < 100.0)

--- a/tests/test_chl.py
+++ b/tests/test_chl.py
@@ -1,0 +1,80 @@
+import socket
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from regional_mom6.chl import interpolate_and_fill_seawifs
+
+SEAWIFS_PATH = "/glade/campaign/cesm/cesmdata/cseg/inputdata/ocn/mom/croc/chl/data/SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc"
+
+
+def on_cisl_machine():
+    """Return True if the current machine is a CISL machine, False otherwise."""
+    return "hpc.ucar.edu" in socket.getfqdn()
+
+
+requires_cisl_machine = pytest.mark.skipif(
+    not on_cisl_machine(),
+    reason="Requires the SeaWiFS chlorophyll climatology, only staged on NCAR/CISL machines",
+)
+
+
+def add_synthetic_bathymetry(expt, tmp_path):
+    """Set up random bathymetry for `expt`, same pattern as test_expt_class.py::test_setup_bathymetry."""
+    bathymetry_file = tmp_path / "bathymetry.nc"
+    bathymetry = np.random.random((100, 100)) * (-100)
+    bathymetry = xr.DataArray(
+        bathymetry,
+        dims=["silly_lat", "silly_lon"],
+        coords={
+            "silly_lat": np.linspace(
+                expt.latitude_extent[0] - 5, expt.latitude_extent[1] + 5, 100
+            ),
+            "silly_lon": np.linspace(
+                expt.longitude_extent[0] - 5, expt.longitude_extent[1] + 5, 100
+            ),
+        },
+    )
+    bathymetry.name = "silly_depth"
+    bathymetry.to_netcdf(bathymetry_file)
+    bathymetry.close()
+
+    expt.setup_bathymetry(
+        bathymetry_path=str(bathymetry_file),
+        longitude_coordinate_name="silly_lon",
+        latitude_coordinate_name="silly_lat",
+        vertical_coordinate_name="silly_depth",
+    )
+
+
+@requires_cisl_machine
+def test_interpolate_and_fill_seawifs(simple_experiment, tmp_path):
+    """Test the creation of chl files directly via interpolate_and_fill_seawifs."""
+    add_synthetic_bathymetry(simple_experiment, tmp_path)
+
+    output_path = tmp_path / "seawifs-clim-1997-2010-chl_test_grid.nc"
+    chl_ds = interpolate_and_fill_seawifs(
+        simple_experiment.m6f_hgrid,
+        simple_experiment.m6f_bathymetry,
+        processed_seawifs_path=SEAWIFS_PATH,
+        output_path=output_path,
+    )
+
+    assert output_path.exists()
+    assert "CHL_A" in chl_ds
+
+
+@requires_cisl_machine
+def test_setup_chl(simple_experiment, tmp_path):
+    """Test experiment.setup_chl, which wraps interpolate_and_fill_seawifs using the experiment's own grid/bathymetry."""
+    add_synthetic_bathymetry(simple_experiment, tmp_path)
+
+    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=SEAWIFS_PATH)
+
+    expected_output = (
+        simple_experiment.mom_input_dir
+        / f"seawifs-clim-1997-2010-{simple_experiment.expt_name}.nc"
+    )
+    assert expected_output.exists()
+    assert "CHL_A" in chl_ds


### PR DESCRIPTION
## Summary
- mom6_forge's `chl.py` (SeaWiFS chlorophyll interpolation, `interpolate_and_fill_seawifs`/`gen_chl_empty_dataset`) is being removed from mom6_forge.
- Move the full implementation into `regional_mom6/chl.py` as-is. Its dependencies (`Grid`, `Topo`, `utils.fill_missing_data`/`compute_subsampling_factor`, `mapping.regrid_with_subsampling`) are unaffected and continue to come from the mom6_forge package, same as `regional_mom6/regional_mom6.py` already does via the `grid.py`/`topo.py` re-export shims.

## Test plan
- [x] `from regional_mom6.chl import interpolate_and_fill_seawifs, gen_chl_empty_dataset` succeeds (mom6-regional-dev env, mom6_forge bumped to 0.3.0)
- [x] `black regional_mom6/chl.py` — no changes needed