### PR TITLE
Expose Grid, Topo, VGrid at top-level regional_mom6 namespace

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -45,6 +45,9 @@ __all__ = [
     "get_glorys_data",
     "RotationMethod",
     "get_rotation_angle",
+    "Grid",
+    "Topo",
+    "VGrid",
 ]
 
 


### PR DESCRIPTION
## Summary
- `regional_mom6.Grid(...)`, `regional_mom6.Topo(...)`, and `regional_mom6.VGrid(...)` now work directly, without needing `regional_mom6.grid.Grid(...)` / `.topo.Topo(...)` / `.vgrid.VGrid(...)`.
- These classes were already imported into `regional_mom6/regional_mom6.py`, but `__init__.py`'s `from .regional_mom6 import *` only re-exports names listed in `__all__`, which didn't include them — this just adds them to `__all__`.

## Test plan
- [x] `pytest tests/` — 42 passed, 4 skipped
- [x] `black --check regional_mom6/` — clean
- [x] Verified `import regional_mom6; regional_mom6.Grid`, `.Topo`, `.VGrid` resolve to the expected classes, and existing exports (e.g. `regional_mom6.experiment`) are unaffected