### PR TITLE
Let Experiment accommodate interior/arbitrary OBC boundaries

### DIFF
--- a/regional_mom6/boundary.py
+++ b/regional_mom6/boundary.py
@@ -1,0 +1,755 @@
+"""
+Boundary: a self-contained description of a single straight, index-aligned
+MOM6 open boundary condition (OBC) line, plus the regridding/rotation/masking/
+writing logic needed to turn raw forcing data into MOM6 OBC segment files.
+
+A ``Boundary`` only ever needs a small slice of a horizontal grid (and,
+optionally, a matching ``mom6_forge.Topo`` for masking) -- it never needs the
+whole ``experiment``/rest of the domain, so it can be built and exercised on
+its own, independent of ``experiment``.
+"""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from regional_mom6 import regridding as rgd
+from regional_mom6.utils import ap2ep, ep2ap, rotate, try_pint_convert
+from regional_mom6.validate import validate_obc_file
+
+# Legacy full-edge cases: (axis held fixed, index along that axis)
+_CARDINAL_AXES = {
+    "south": ("nyp", 0),
+    "north": ("nyp", -1),
+    "west": ("nxp", 0),
+    "east": ("nxp", -1),
+}
+
+
+class Boundary:
+    """
+    The geometry of a single straight boundary line, plus the ability to
+    regrid raw forcing data onto it and write MOM6-ready segment files.
+
+    Fields (set once at construction, never mutated):
+        lon (xarray.DataArray): 1-D longitude along the boundary.
+        lat (xarray.DataArray): 1-D latitude along the boundary, same dims as ``lon``.
+        angle (xarray.DataArray): Rotation angle (degrees) at each point along the
+            boundary, same dims as ``lon``.
+        segment_name (str): Name of the segment, e.g., ``'segment_001'``.
+        parallel (str): ``"nx"`` or ``"ny"`` -- the along-boundary logical dim prefix.
+        perpendicular (str): ``"ny"`` or ``"nx"`` -- the across-boundary logical dim prefix.
+        axis_to_expand (int): Which axis the "main" coordinate corresponds to when
+            re-adding the perpendicular axis during regridding.
+        mask (Optional[xarray.DataArray]): 1-D ocean(1)/land(0) mask along the boundary,
+            same dims as ``lon``. ``None`` means no masking is applied.
+    """
+
+    def __init__(
+        self,
+        *,
+        lon,
+        lat,
+        angle,
+        segment_name,
+        parallel,
+        perpendicular,
+        axis_to_expand,
+        mask=None,
+    ):
+        self.lon = lon
+        self.lat = lat
+        self.angle = angle
+        self.segment_name = segment_name
+        self.parallel = parallel
+        self.perpendicular = perpendicular
+        self.axis_to_expand = axis_to_expand
+        self.mask = mask
+        self._regridders = None
+        self._tidal_regridders = None
+
+    @classmethod
+    def from_hgrid(
+        cls,
+        hgrid: xr.Dataset,
+        *,
+        axis: str,
+        index: int,
+        segment_name: str,
+        index_range=None,
+        topo=None,
+    ) -> "Boundary":
+        """
+        Slice a straight boundary line out of ``hgrid``.
+
+        Arguments:
+            hgrid (xarray.Dataset): The horizontal supergrid dataset.
+            axis (str): Which supergrid axis is held fixed -- ``"nyp"`` for a boundary
+                that runs east-west (varies in x), ``"nxp"`` for one that runs
+                north-south (varies in y).
+            index (int): The fixed index along ``axis``. ``0`` or ``-1`` gives a full
+                outer edge (the legacy north/south/east/west cases); any other value
+                gives an interior/arbitrary line.
+            segment_name (str): Name of the segment, e.g., ``'segment_001'``.
+            index_range (slice, optional): Restrict the boundary to part of the line
+                along the other (parallel) axis instead of its full length.
+                Default ``None`` (whole line).
+            topo (mom6_forge.topo.Topo, optional): A ``Topo`` instance for the same
+                grid. If given, its ``supergridmask`` is sliced the same way to build
+                the boundary's ocean/land mask. Default ``None`` (no masking).
+        """
+        if axis not in ("nyp", "nxp"):
+            raise ValueError("axis must be one of: 'nyp', 'nxp'")
+
+        lon = hgrid["x"].isel({axis: index})
+        lat = hgrid["y"].isel({axis: index})
+        if "angle_dx" in hgrid:
+            angle = hgrid["angle_dx"].isel({axis: index})
+        else:
+            warnings.warn(
+                "hgrid has no 'angle_dx' variable -- assuming zero rotation for this "
+                "boundary. If your grid is rotated, compute angle_dx yourself (e.g. "
+                "via mom6_forge's grid generation) before calling from_hgrid."
+            )
+            angle = xr.zeros_like(lon)
+        mask = topo.supergridmask.isel({axis: index}) if topo is not None else None
+
+        parallel_axis = "nxp" if axis == "nyp" else "nyp"
+        if index_range is not None:
+            lon = lon.isel({parallel_axis: index_range})
+            lat = lat.isel({parallel_axis: index_range})
+            angle = angle.isel({parallel_axis: index_range})
+            if mask is not None:
+                mask = mask.isel({parallel_axis: index_range})
+
+        parallel, perpendicular, axis_to_expand = (
+            ("nx", "ny", 2) if axis == "nyp" else ("ny", "nx", 3)
+        )
+        new_dim_name = f"{parallel}_{segment_name}"
+        lon = lon.rename({parallel_axis: new_dim_name})
+        lat = lat.rename({parallel_axis: new_dim_name})
+        angle = angle.rename({parallel_axis: new_dim_name})
+        if mask is not None:
+            mask = mask.rename({parallel_axis: new_dim_name})
+
+        return cls(
+            lon=lon,
+            lat=lat,
+            angle=angle,
+            segment_name=segment_name,
+            parallel=parallel,
+            perpendicular=perpendicular,
+            axis_to_expand=axis_to_expand,
+            mask=mask,
+        )
+
+    @classmethod
+    def cardinal(
+        cls,
+        hgrid: xr.Dataset,
+        orientation: str,
+        segment_name: str,
+        index_range=None,
+        topo=None,
+    ) -> "Boundary":
+        """
+        Convenience wrapper for the 4 legacy full-edge cases.
+
+        Arguments:
+            hgrid (xarray.Dataset): The horizontal supergrid dataset.
+            orientation (str): One of ``'north'``, ``'south'``, ``'east'``, ``'west'``
+                (case-insensitive).
+            segment_name (str): Name of the segment, e.g., ``'segment_001'``.
+            index_range (slice, optional): Restrict the boundary to part of the edge.
+                Default ``None`` (the whole edge).
+            topo (mom6_forge.topo.Topo, optional): See :meth:`from_hgrid`.
+        """
+        orientation = orientation.lower()
+        if orientation not in _CARDINAL_AXES:
+            raise ValueError(
+                "orientation must be one of: 'north', 'south', 'east', or 'west'. "
+                "For a boundary that isn't a full outer edge, use Boundary.from_hgrid directly."
+            )
+        axis, index = _CARDINAL_AXES[orientation]
+        return cls.from_hgrid(
+            hgrid,
+            axis=axis,
+            index=index,
+            segment_name=segment_name,
+            index_range=index_range,
+            topo=topo,
+        )
+
+    @property
+    def _coords_ds(self) -> xr.Dataset:
+        """The boundary's lon/lat as a small xarray.Dataset, for use as the
+        ``xesmf.Regridder`` output grid. ``lon``/``lat`` must be actual
+        coordinates (not just data variables) for ``xe.Regridder``'s
+        ``locstream_out`` mode to carry them through to the regridded output."""
+        ds = xr.Dataset({"lon": self.lon, "lat": self.lat})
+        return ds.assign_coords(lat=ds["lat"], lon=ds["lon"])
+
+    def regrid_velocity_tracers(
+        self,
+        infile,
+        varnames: dict,
+        outfolder,
+        startdate,
+        arakawa_grid="A",
+        regridding_method="bilinear",
+        time_units="days",
+        calendar="gregorian",
+        fill_method=rgd.fill_missing_data,
+        regridders=None,
+        repeat_year_forcing=False,
+    ):
+        """
+        Cut out and interpolate the velocities and tracers onto this boundary.
+
+        Arguments:
+            infile (Union[str, Path]): Path to the raw, unprocessed boundary segment.
+            varnames (Dict[str, str]): Mapping between the variable/dimension names and
+                standard naming convention of this pipeline, e.g., ``{"xh": "longitude",
+                "yh": "latitude", "salt": "salinity", ...}``. Key "tracers" points to a
+                nested dictionary of tracers to include in boundary.
+            outfolder (Union[str, Path]): Path to folder where the model inputs will
+                be stored.
+            startdate (str): The starting date to use in the segment calendar.
+            arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary
+                forcing. Either ``'A'`` (default), ``'B'``, or ``'C'``.
+            regridding_method (str): Regridding method to use throughout the function.
+                Default is ``'bilinear'``.
+            time_units (str): The units used by the raw forcing files. Default ``'days'``.
+            calendar (str): Calendar to use for the time coordinate. Default ``'gregorian'``.
+            fill_method (Function): Fill method to use throughout the function. Default
+                is ``rgd.fill_missing_data``.
+            regridders (dict, optional): Pre-built regridders with keys ``"tracers"``,
+                ``"u"``, ``"v"``. If provided, regridder creation is skipped entirely --
+                useful when calling this method multiple times for different time
+                windows on the same boundary (pass ``boundary._regridders`` from a
+                prior call). Default ``None`` -- regridders are built and cached on
+                ``self._regridders`` for reuse on the next call.
+            repeat_year_forcing (Optional[bool]): When ``True`` the experiment runs
+                with repeat-year forcing. When ``False`` (default) inter-annual
+                forcing is used.
+        """
+        reprocessed_var_map = rgd.apply_arakawa_grid_mapping(
+            var_mapping=varnames, arakawa_grid=arakawa_grid
+        )
+
+        outfolder = Path(outfolder)
+        (outfolder / "weights").mkdir(exist_ok=True)
+
+        rawseg = xr.open_mfdataset(infile, decode_times=False, engine="netcdf4")
+
+        # Convert z coordinates to meters if pint-enabled
+        if type(reprocessed_var_map["depth_coord"]) != list:
+            dc_list = [reprocessed_var_map["depth_coord"]]
+        else:
+            dc_list = reprocessed_var_map["depth_coord"]
+        for dc in dc_list:
+            rawseg[dc] = try_pint_convert(rawseg[dc], "m", dc)
+
+        if regridders is None:
+            regridders = rgd.create_vt_regridders(
+                reprocessed_var_map,
+                rawseg,
+                self._coords_ds,
+                outfolder,
+                regridding_method,
+                self.segment_name,
+            )
+        self._regridders = regridders
+
+        u_regridded = regridders["u"](
+            rawseg[reprocessed_var_map["u_var_name"]].rename(
+                {
+                    reprocessed_var_map["u_x_coord"]: "lon",
+                    reprocessed_var_map["u_y_coord"]: "lat",
+                }
+            )
+        )
+        v_regridded = regridders["v"](
+            rawseg[reprocessed_var_map["v_var_name"]].rename(
+                {
+                    reprocessed_var_map["v_x_coord"]: "lon",
+                    reprocessed_var_map["v_y_coord"]: "lat",
+                }
+            )
+        )
+        tracers_regridded = regridders["tracers"](
+            rawseg[
+                [reprocessed_var_map["eta_var_name"]]
+                + list(reprocessed_var_map["tracer_var_names"].values())
+            ].rename(
+                {
+                    reprocessed_var_map["tracer_x_coord"]: "lon",
+                    reprocessed_var_map["tracer_y_coord"]: "lat",
+                }
+            )
+        )
+
+        rotated_u, rotated_v = rotate(
+            u_regridded,
+            v_regridded,
+            radian_angle=np.radians(self.angle.values),
+        )
+
+        rotated_u.name = reprocessed_var_map["u_var_name"]
+        rotated_v.name = reprocessed_var_map["v_var_name"]
+        segment_out = xr.merge([rotated_u, rotated_v, tracers_regridded])
+
+        ## segment out now contains our interpolated boundary.
+        ## Now, we need to fix up all the metadata and save
+        segment_out = segment_out.rename(
+            {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
+        )
+
+        ## Convert temperatures to celsius # use pint
+        depth_coord = reprocessed_var_map["depth_coord"]
+        if type(reprocessed_var_map["depth_coord"]) == list:
+            for dc in reprocessed_var_map["depth_coord"]:
+                if (
+                    dc
+                    in segment_out[reprocessed_var_map["tracer_var_names"]["temp"]].dims
+                ):  # At least one must be true
+                    depth_coord = dc
+
+        if "since" not in time_units:
+            times = xr.DataArray(
+                np.arange(
+                    0,  #! Indexing everything from start of experiment = simple but maybe counterintutive?
+                    segment_out[reprocessed_var_map["time_var_name"]].shape[
+                        0
+                    ],  ## Time is indexed from start date of window
+                    dtype=float,
+                ),
+                dims=["time"],
+            )
+
+            # This to change the time coordinate.
+            segment_out = rgd.add_or_update_time_dim(
+                segment_out, times, reprocessed_var_map["depth_coord"]
+            )
+
+            segment_out.time.attrs = {
+                "calendar": calendar,
+                "units": f"{time_units} since {startdate}",
+            }
+        else:
+            segment_out.time.attrs = {
+                "calendar": calendar,
+                "units": time_units,
+            }
+
+        # Here, keep in mind that 'var' keeps track of the mom6 variable names we want, and self.tracers[var]
+        # will return the name of the variable from the original data
+        output_var_list = []
+        allfields = {
+            **reprocessed_var_map["tracer_var_names"],
+            "u": reprocessed_var_map["u_var_name"],
+            "v": reprocessed_var_map["v_var_name"],
+            "eta": reprocessed_var_map["eta_var_name"],
+        }  ## Combine all fields into one flattened dictionary to iterate over as we fix metadata
+
+        for (
+            var
+        ) in (
+            allfields
+        ):  ## Replace with more generic list of tracer variables that might be included?
+            v = f"{var}_{self.segment_name}"
+            ## Rename each variable in dataset
+            segment_out = segment_out.rename({allfields[var]: v})
+            output_var_list.append(v)
+
+            # Try Pint Conversion
+            if var in rgd.main_field_target_units:
+                # Apply raw data units if they exist
+                units = rawseg[allfields[var]].attrs.get("units")
+                if units is not None:
+                    segment_out[v].attrs["units"] = units
+
+                segment_out[v] = try_pint_convert(
+                    segment_out[v], rgd.main_field_target_units[var], var
+                )
+
+            # Find out if the tracer has depth, and if so, what is it's z dimension (z dimension being a list is an edge case for MARBL BGC)
+            variable_has_depth = False
+            depth_coord = None
+            if type(reprocessed_var_map["depth_coord"]) != list:
+                dc_list = [reprocessed_var_map["depth_coord"]]
+            else:
+                dc_list = reprocessed_var_map["depth_coord"]
+
+            for dc in dc_list:
+                if dc in segment_out[v].dims:
+                    depth_coord = dc
+                    variable_has_depth = True
+                    break
+
+            if variable_has_depth:
+                segment_out = rgd.vertical_coordinate_encoding(
+                    segment_out,
+                    v,
+                    self.segment_name,
+                    depth_coord,
+                )
+
+            segment_out = rgd.add_secondary_dimension(
+                segment_out, v, self, self.segment_name
+            )
+            if variable_has_depth:
+                segment_out = rgd.generate_layer_thickness(
+                    segment_out,
+                    v,
+                    self.segment_name,
+                    depth_coord,
+                )
+
+        # Here, do a foolproof (hopefully) manual conversion from K -> C just in case
+        # pint doesn't manage to do so. Pint is finicky, but required for BGC fields. However,
+        # we're making sure that temp will always be in C not K as this is a big problem!
+        if (
+            np.nanmin(
+                segment_out[f"temp_{self.segment_name}"].isel(
+                    {
+                        reprocessed_var_map["time_var_name"]: 0,
+                        f"nz_{self.segment_name}_temp": 0,
+                    }
+                )
+            )
+            > 100
+        ):
+            segment_out[f"temp_{self.segment_name}"] -= 273.15
+            segment_out[f"temp_{self.segment_name}"].attrs["units"] = "degrees Celsius"
+
+        # fill in NaNs
+        segment_out = fill_method(
+            segment_out,
+            xdim=f"{self.parallel}_{self.segment_name}",
+            zdim=reprocessed_var_map["depth_coord"],
+        )
+
+        # Overwrite the actual lat/lon values in the dimensions, replace with incrementing integers
+        segment_out[f"{self.perpendicular}_{self.segment_name}"] = [0]
+
+        segment_out[f"{self.parallel}_{self.segment_name}"] = np.arange(
+            segment_out[f"{self.parallel}_{self.segment_name}"].size
+        )
+        segment_out[f"ny_{self.segment_name}"].attrs["axis"] = "Y"
+        segment_out[f"nx_{self.segment_name}"].attrs["axis"] = "X"
+        encoding_dict = {
+            "time": {"dtype": "double"},
+            f"nx_{self.segment_name}": {
+                "dtype": "int32",
+            },
+            f"ny_{self.segment_name}": {
+                "dtype": "int32",
+            },
+        }
+        segment_out = rgd.mask_dataset(segment_out, self)
+        encoding_dict = rgd.generate_encoding(
+            segment_out,
+            encoding_dict,
+            default_fill_value=1.0e20,
+        )
+        # If repeat-year forcing, add modulo coordinate
+        if repeat_year_forcing:
+            segment_out["time"] = segment_out["time"].assign_attrs({"modulo": " "})
+        segment_out.load().to_netcdf(
+            outfolder / f"forcing_obc_{self.segment_name}.nc",
+            encoding=encoding_dict,
+            unlimited_dims="time",
+        )
+
+        validate_obc_file(
+            segment_out,
+            output_var_list,
+            encoding_dict,
+            surface_var=f"eta_{self.segment_name}",
+        )
+
+        return segment_out, encoding_dict
+
+    def regrid_tides(
+        self,
+        tpxo_v,
+        tpxo_u,
+        tpxo_h,
+        times,
+        outfolder,
+        startdate,
+        regridding_method="bilinear",
+        fill_method=rgd.fill_missing_data,
+        regridders=None,
+        repeat_year_forcing=False,
+    ):
+        """
+        Regrids and interpolates the tidal data for MOM6 onto this boundary. Steps
+        include:
+
+        - Read raw tidal data (all constituents)
+        - Perform minor transformations/conversions
+        - Regrid the tidal elevation, and tidal velocity
+        - Encode the output
+
+        Arguments:
+            tpxo_v, tpxo_u, tpxo_h (xarray.Dataset): Specific adjusted for MOM6 tpxo
+                datasets (adjusted with :func:`~experiment.setup_boundary_tides`).
+            times (pd.DateRange): The start date of our model period.
+            outfolder (Union[str, Path]): Path to folder where the model inputs will
+                be stored.
+            startdate (str): The starting date to use in the segment calendar.
+            regridding_method (str): Regridding method to use throughout the function.
+                Default is ``'bilinear'``.
+            fill_method (Function): Fill method to use throughout the function.
+                Default is ``rgd.fill_missing_data``.
+            regridders (dict, optional): Pre-built regridders with keys ``"elev"``,
+                ``"u"``, ``"v"``. If provided, regridder creation is skipped entirely
+                -- useful when calling this method multiple times on the same
+                boundary (pass ``boundary._tidal_regridders`` from a prior call).
+                Default ``None`` -- regridders are built and cached on
+                ``self._tidal_regridders`` for reuse on the next call.
+            repeat_year_forcing (Optional[bool]): Unused for tides (kept for
+                signature symmetry with :meth:`regrid_velocity_tracers`).
+
+        Returns:
+            netCDF files: Regridded tidal velocity and elevation files in ``outfolder``.
+
+        Code credit:
+
+        .. code-block:: bash
+
+            Author(s): GFDL, James Simkins, Rob Cermak, and contributors
+            Year: 2022
+            Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
+            Version: N/A
+            Type: Python Functions, Source Code
+            Web Address: https://github.com/jsimkins2/nwa25
+        """
+        outfolder = Path(outfolder)
+        (outfolder / "weights").mkdir(exist_ok=True)
+
+        if regridders is None:
+            regridders = {
+                "elev": rgd.create_regridder(
+                    tpxo_h[["lon", "lat", "hRe"]],
+                    self._coords_ds,
+                    outfolder
+                    / "weights"
+                    / f"bilinear_tidal_elev_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+                "u": rgd.create_regridder(
+                    tpxo_u[["lon", "lat", "uRe"]],
+                    self._coords_ds,
+                    outfolder
+                    / "weights"
+                    / f"bilinear_tidal_u_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+                "v": rgd.create_regridder(
+                    tpxo_v[["lon", "lat", "vRe"]],
+                    self._coords_ds,
+                    outfolder
+                    / "weights"
+                    / f"bilinear_tidal_v_weights_{self.segment_name}.nc",
+                    method=regridding_method,
+                ),
+            }
+        self._tidal_regridders = regridders
+        regrid = regridders["elev"]
+
+        ########## Tidal Elevation: Horizontally interpolate elevation components ############
+
+        redest = regrid(tpxo_h[["lon", "lat", "hRe"]])
+        imdest = regrid(tpxo_h[["lon", "lat", "hIm"]])
+
+        # Fill missing data.
+        # Need to do this first because complex would get converted to real
+        redest = fill_method(
+            redest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+        redest = redest["hRe"]
+        imdest = fill_method(
+            imdest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+        imdest = imdest["hIm"]
+
+        # Convert complex
+        cplex = redest + 1j * imdest
+
+        # Convert to real amplitude and phase.
+        ds_ap = xr.Dataset({f"zamp_{self.segment_name}": np.abs(cplex)})
+
+        # np.angle doesn't return dataarray
+        ds_ap[f"zphase_{self.segment_name}"] = (
+            ("constituent", f"{self.parallel}_{self.segment_name}"),
+            -1 * np.angle(cplex),
+        )  # radians
+
+        # Add time coordinate and transpose so that time is first,
+        # so that it can be the unlimited dimension
+        times = xr.DataArray(
+            pd.date_range(startdate, periods=1),
+            dims=["time"],
+        )
+
+        ds_ap = rgd.add_or_update_time_dim(ds_ap, times)
+        ds_ap = ds_ap.transpose(
+            "time", "constituent", f"{self.parallel}_{self.segment_name}"
+        )
+
+        self.encode_tidal_files_and_output(ds_ap, "tz", outfolder)
+
+        ########### Regrid Tidal Velocity ######################
+
+        regrid_u = regridders["u"]
+        regrid_v = regridders["v"]
+
+        # Interpolate each real and imaginary parts to self.
+        uredest = regrid_u(tpxo_u[["lon", "lat", "uRe"]])["uRe"]
+        uimdest = regrid_u(tpxo_u[["lon", "lat", "uIm"]])["uIm"]
+        vredest = regrid_v(tpxo_v[["lon", "lat", "vRe"]])["vRe"]
+        vimdest = regrid_v(tpxo_v[["lon", "lat", "vIm"]])["vIm"]
+
+        # Fill missing data.
+        # Need to do this first because complex would get converted to real
+        uredest = fill_method(
+            uredest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+        uimdest = fill_method(
+            uimdest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+        vredest = fill_method(
+            vredest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+        vimdest = fill_method(
+            vimdest, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+
+        # Convert to complex, remaining separate for u and v.
+        ucplex = uredest + 1j * uimdest
+        vcplex = vredest + 1j * vimdest
+
+        # Convert complex u and v to ellipse,
+        # rotate ellipse from earth-relative to model-relative,
+        # and convert ellipse back to amplitude and phase.
+        SEMA, ECC, INC, PHA = ap2ep(ucplex, vcplex)
+
+        # Rotate
+        INC -= np.radians(self.angle.data[np.newaxis, :])
+
+        ua, va, up, vp = ep2ap(SEMA, ECC, INC, PHA)
+        # Convert to real amplitude and phase.
+
+        ds_ap = xr.Dataset(
+            {f"uamp_{self.segment_name}": ua, f"vamp_{self.segment_name}": va}
+        )
+        # up, vp aren't dataarraysf
+        ds_ap[f"uphase_{self.segment_name}"] = (
+            ("constituent", f"{self.parallel}_{self.segment_name}"),
+            up,
+        )  # radians
+        ds_ap[f"vphase_{self.segment_name}"] = (
+            ("constituent", f"{self.parallel}_{self.segment_name}"),
+            vp,
+        )  # radians
+
+        times = xr.DataArray(
+            pd.date_range(startdate, periods=1),
+            dims=["time"],
+        )
+        ds_ap = rgd.add_or_update_time_dim(ds_ap, times)
+        ds_ap = ds_ap.transpose(
+            "time", "constituent", f"{self.parallel}_{self.segment_name}"
+        )
+
+        # Some things may have become missing during the transformation
+        ds_ap = fill_method(
+            ds_ap, xdim=f"{self.parallel}_{self.segment_name}", zdim=None
+        )
+
+        self.encode_tidal_files_and_output(ds_ap, "tu", outfolder)
+
+        return
+
+    def encode_tidal_files_and_output(self, ds, filename, outfolder):
+        """
+        This method:
+
+        - Expands the dimensions (with the segment name)
+        - Renames some dimensions to be more specific to the segment
+        - Provides an output file encoding
+        - Exports the files.
+
+        Arguments:
+            ds (xarray.Dataset): The processed tidal dataset
+            filename (str): The output file name
+            outfolder (Union[str, Path]): The output folder to save the tidal files into
+
+        Returns:
+            netCDF files: Regridded [FILENAME] files in ``outfolder/[filename]_[segmentname].nc``
+
+        Code credit:
+
+        .. code-block:: bash
+
+            Author(s): GFDL, James Simkins, Rob Cermak, and contributors
+            Year: 2022
+            Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
+            Version: N/A
+            Type: Python Functions, Source Code
+            Web Address: https://github.com/jsimkins2/nwa25
+        """
+        outfolder = Path(outfolder)
+
+        ## Expand Tidal Dimensions ##
+        output_var_list = []
+        for var in ds:
+            ds = rgd.add_secondary_dimension(ds, str(var), self, self.segment_name)
+            output_var_list.append(var)
+
+        ## Rename Tidal Dimensions ##
+        ds = ds.rename(
+            {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
+        )
+
+        if self.mask is not None:
+            print(
+                "A land/ocean mask has been provided to the regridding tides function. "
+                "Masking tides dataset with it may result in errors like large surface values one timestep in. "
+                "To avoid masking tides, don't pass a topo to Boundary construction for tidal-only use."
+            )
+        ds = rgd.mask_dataset(ds, self)
+        ## Perform Encoding ##
+
+        fname = f"{filename}_{self.segment_name}.nc"
+        # Set format and attributes for coordinates, including time if it does not already have calendar attribute
+        # (may change this to detect whether time is a time type or a float).
+        # Need to include the fillvalue or it will be back to nan
+        encoding = {
+            "time": dict(dtype="float64", calendar="gregorian", _FillValue=1.0e20),
+            f"lon_{self.segment_name}": dict(dtype="float64", _FillValue=1.0e20),
+            f"lat_{self.segment_name}": dict(dtype="float64", _FillValue=1.0e20),
+        }
+        encoding = rgd.generate_encoding(ds, encoding, default_fill_value=1.0e20)
+
+        validate_obc_file(
+            ds,
+            output_var_list,
+            encoding,
+            surface_var="",
+        )
+
+        ## Export Files ##
+        ds.to_netcdf(
+            outfolder / fname,
+            engine="netcdf4",
+            encoding=encoding,
+            unlimited_dims="time",
+        )
+        return ds

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -22,7 +22,7 @@ from regional_mom6.config import Config
 from regional_mom6.grid import Grid
 from regional_mom6.vgrid import VGrid
 from regional_mom6.topo import Topo
-from regional_mom6.boundary import Boundary
+from regional_mom6.segment import Segment
 from regional_mom6.utils import (
     ap2ep,
     ep2ap,
@@ -42,7 +42,7 @@ warnings.filterwarnings("ignore")
 
 __all__ = [
     "experiment",
-    "Boundary",
+    "Segment",
     "get_glorys_data",
     "RotationMethod",
     "get_rotation_angle",
@@ -71,7 +71,7 @@ def get_rotation_angle(
 ) -> xr.DataArray:
     """Return the rotation angle (degrees) for the whole hgrid.
 
-    Note: boundary segments no longer use this function -- ``Boundary`` reads
+    Note: OBC segments no longer use this function -- ``Segment`` reads
     ``hgrid["angle_dx"]`` directly. This remains for whole-grid uses, e.g.
     :func:`~experiment.setup_initial_condition`.
 
@@ -658,17 +658,17 @@ class experiment:
             )
         return val
 
-    def _get_boundary(self, orientation, bathymetry_path=None):
+    def _get_segment(self, orientation, bathymetry_path=None):
         """
-        Build (or reuse a cached) :class:`~regional_mom6.boundary.Boundary` for the
+        Build (or reuse a cached) :class:`~regional_mom6.segment.Segment` for the
         given cardinal ``orientation``.
 
-        The first call for a given ``orientation`` builds the ``Boundary`` (masking
+        The first call for a given ``orientation`` builds the ``Segment`` (masking
         with the bathymetry at ``bathymetry_path`` if given) and caches it in
         ``self.segments``; subsequent calls for the same ``orientation`` reuse the
-        cached ``Boundary`` regardless of ``bathymetry_path`` -- this lets
+        cached ``Segment`` regardless of ``bathymetry_path`` -- this lets
         :func:`~setup_ocean_state_boundaries` and :func:`~setup_boundary_tides` share
-        one ``Boundary`` per orientation instead of each re-deriving it from the grid.
+        one ``Segment`` per orientation instead of each re-deriving it from the grid.
         """
         if orientation in self.segments:
             return self.segments[orientation]
@@ -689,9 +689,9 @@ class experiment:
         segment_name = "segment_{:03d}".format(
             self.find_MOM6_rectangular_orientation(orientation)
         )
-        boundary = Boundary.cardinal(self.hgrid, orientation, segment_name, topo=topo)
-        self.segments[orientation] = boundary
-        return boundary
+        segment = Segment.cardinal(self.hgrid, orientation, segment_name, topo=topo)
+        self.segments[orientation] = segment
+        return segment
 
     def _make_hgrid(self):
         """
@@ -1288,7 +1288,7 @@ class experiment:
         if len(self.boundaries) > 4:
             raise ValueError(
                 "This method only supports up to four boundaries. To set up more complex boundary shapes, construct a "
-                "regional_mom6.boundary.Boundary directly (e.g. via Boundary.from_hgrid) and call its "
+                "regional_mom6.segment.Segment directly (e.g. via Segment.from_hgrid) and call its "
                 "regrid_velocity_tracers method for each boundary."
             )
 
@@ -1401,9 +1401,9 @@ class experiment:
             raise FileNotFoundError(
                 f"Boundary file not found at {path_to_bc}. Please ensure that the files are named in the format `east_unprocessed.nc`."
             )
-        boundary = self._get_boundary(orientation, bathymetry_path=bathymetry_path)
+        segment = self._get_segment(orientation, bathymetry_path=bathymetry_path)
 
-        boundary.regrid_velocity_tracers(
+        segment.regrid_velocity_tracers(
             infile=path_to_bc,  # location of raw boundary
             varnames=varnames,
             outfolder=self.mom_input_dir,
@@ -1443,11 +1443,11 @@ class experiment:
 
         The tidal data functions are sourced from the GFDL NWA25 and modified so that:
 
-        - Converted code for regional-mom6 :class:`~regional_mom6.boundary.Boundary` class
+        - Converted code for regional-mom6 :class:`~regional_mom6.segment.Segment` class
         - Implemented horizontal subsetting.
         - Combined all functions of NWA25 into a four function process (in the style of regional-mom6), i.e.,
-          :func:`~experiment.setup_boundary_tides`, :meth:`Boundary.from_hgrid`, :meth:`Boundary.regrid_tides`, and
-          :meth:`Boundary.encode_tidal_files_and_output`.
+          :func:`~experiment.setup_boundary_tides`, :meth:`Segment.from_hgrid`, :meth:`Segment.regrid_tides`, and
+          :meth:`Segment.encode_tidal_files_and_output`.
 
         Code credit:
 
@@ -1510,12 +1510,12 @@ class experiment:
         for b in self.boundaries:
             print("Processing {} boundary...".format(b), end="")
 
-            # If ocean-state setup already built this boundary, reuse it instead of
+            # If ocean-state setup already built this segment, reuse it instead of
             # re-deriving it from the grid again.
-            boundary = self._get_boundary(b, bathymetry_path=bathymetry_path)
+            segment = self._get_segment(b, bathymetry_path=bathymetry_path)
 
             # Output and regrid tides
-            boundary.regrid_tides(
+            segment.regrid_tides(
                 tpxo_v,
                 tpxo_u,
                 tpxo_h,
@@ -1758,13 +1758,7 @@ class experiment:
             ## Position and Config
             key_POSITION = key_start
 
-            rect_MOM6_index_dir = {
-                "south": '"J=0,I=0:N',
-                "north": '"J=N,I=N:0',
-                "east": '"I=N,J=0:N',
-                "west": '"I=0,J=N:0',
-            }
-            index_str = rect_MOM6_index_dir[seg]
+            index_str = '"' + self._get_segment(seg).mom6_obc_position_string()
 
             MOM_override_dict[key_POSITION]["value"] = (
                 index_str + ',FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN"'

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2207,4 +2207,3 @@ class experiment:
                     unlimited_dims="time",
                     encoding={vname: {"dtype": "double"}},
                 )
-

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -193,7 +193,13 @@ class experiment:
         tidal_constituents (List[str]): List of tidal constituents to be used in the experiment. Default is ``["M2", "S2", "N2", "K2", "K1", "O1", "P1", "Q1", "MM", "MF"]``.
         create_empty (bool): If ``True``, the experiment object is initialized empty. This is used for testing and experienced user manipulation.
         expt_name (str): The name of the experiment (for config file use)
-        boundaries (List[str]): List of (rectangular) boundaries to be set. Default is ``["south", "north", "west", "east"]``. The boundaries are set as (list index + 1) in MOM_override in the order of the list, and less than 4 boundaries can be set.
+        boundaries (List[Union[str, Segment]]): List of boundaries to be set, each entry either a
+            cardinal direction string (``"south"``, ``"north"``, ``"west"``, ``"east"``) or an
+            interior/partial-edge :class:`~regional_mom6.segment.Segment` (e.g. built via
+            :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`). Default is
+            ``["south", "north", "west", "east"]``. Segments are numbered ``1..len(boundaries)``
+            purely by their position in this list (used for ``OBC_SEGMENT_00N`` in MOM_override
+            and for output filenames) -- any number of boundaries can be set, not just 4.
         regridding_method (str): regridding method to use throughout the entire experiment. Default is ``'bilinear'``. Any other xesmf regridding method can be used.
         fill_method (Function): The fill function to be used after regridding datasets. it takes a xarray DataArray and returns a filled DataArray. Default is ``rgd.fill_missing_data``.
     """
@@ -660,40 +666,40 @@ class experiment:
         error_message = f"{name} not found. Available methods and attributes are: {available_methods}"
         raise AttributeError(error_message)
 
-    def find_MOM6_rectangular_orientation(self, input):
+    def _segment_number(self, boundary):
         """
-        Convert between MOM6 boundary and the specific segment number needed, or the inverse.
+        The 1-based position of ``boundary`` in ``self.boundaries`` -- the number
+        used everywhere a segment needs one (``segment_00N``, ``OBC_SEGMENT_00N``,
+        etc). Purely positional: a cardinal direction is just one kind of boundary
+        entry, an interior/arbitrary ``Segment`` is another, and neither has an
+        inherent "number" outside of where it sits in the list.
         """
+        return self.boundaries.index(boundary) + 1
 
-        direction_dir = {}
-        counter = 1
-        for b in self.boundaries:
-            direction_dir[b] = counter
-            counter += 1
-        direction_dir_inv = {v: k for k, v in direction_dir.items()}
-        merged_dict = {**direction_dir, **direction_dir_inv}
-        try:
-            val = merged_dict[input]
-        except KeyError:
-            raise ValueError(
-                "Invalid direction or segment number for MOM6 rectangular orientation"
-            )
-        return val
-
-    def _get_segment(self, orientation, bathymetry_path=None):
+    def _get_segment(self, boundary, bathymetry_path=None):
         """
         Build (or reuse a cached) :class:`~regional_mom6.segment.Segment` for the
-        given cardinal ``orientation``.
+        given ``boundary`` entry -- a cardinal direction string, or an
+        already-built :class:`~regional_mom6.segment.Segment` (e.g. an interior or
+        partial-edge line from :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`).
 
-        The first call for a given ``orientation`` builds the ``Segment`` (masking
+        The first call for a given ``boundary`` builds the ``Segment`` (masking
         with the bathymetry at ``bathymetry_path`` if given) and caches it in
-        ``self.segments``; subsequent calls for the same ``orientation`` reuse the
-        cached ``Segment`` regardless of ``bathymetry_path`` -- this lets
-        :func:`~setup_ocean_state_boundaries` and :func:`~setup_boundary_tides` share
-        one ``Segment`` per orientation instead of each re-deriving it from the grid.
+        ``self.segments`` keyed by ``boundary``'s position in ``self.boundaries``;
+        subsequent calls reuse the cached ``Segment`` regardless of
+        ``bathymetry_path`` -- this lets :func:`~setup_ocean_state_boundaries` and
+        :func:`~setup_boundary_tides` share one ``Segment`` per boundary instead of
+        each re-deriving it from the grid.
+
+        A ``Segment`` boundary is always re-cut to the canonical
+        ``segment_{i:03d}`` name for its position ``i`` (via
+        :meth:`Segment.from_spec`/:meth:`Segment.to_spec`), regardless of whatever
+        name it was originally given -- that canonical name is what MOM6's output
+        files and ``OBC_SEGMENT_00i`` config expect.
         """
-        if orientation in self.segments:
-            return self.segments[orientation]
+        number = self._segment_number(boundary)
+        if number in self.segments:
+            return self.segments[number]
 
         topo = None
         if bathymetry_path is not None:
@@ -708,12 +714,104 @@ class experiment:
             except Exception:
                 topo = None
 
-        segment_name = "segment_{:03d}".format(
-            self.find_MOM6_rectangular_orientation(orientation)
-        )
-        segment = Segment.cardinal(self.hgrid, orientation, segment_name, topo=topo)
-        self.segments[orientation] = segment
+        segment_name = "segment_{:03d}".format(number)
+        if isinstance(boundary, Segment):
+            segment = Segment.from_spec(
+                self.hgrid, boundary.to_spec(), segment_name, topo=topo
+            )
+        else:
+            segment = Segment.cardinal(self.hgrid, boundary, segment_name, topo=topo)
+        self.segments[number] = segment
         return segment
+
+    def _validate_boundary_orientations(self):
+        """
+        Guard-rail for interior/partial-edge boundaries: MOM6 requires a segment's
+        along-segment index range to run in the direction that keeps the domain
+        interior on the left when walking the full perimeter counter-clockwise (see
+        the `MOM6 OBC wiki <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_).
+        Cardinal boundaries always get this right (hardcoded in ``Segment.cardinal``);
+        an interior ``Segment`` supplies its own ``mom6_index_reverse``, which is easy
+        to get backwards. This checks that choice against the bathymetry wherever the
+        answer is unambiguous (land clearly on one side only) and raises if it's
+        wrong. Genuinely ambiguous cases (open ocean on both sides, e.g. a mid-domain
+        nesting cut with no adjacent coastline) are silently allowed through -- there's
+        no geometric way to pick a side from the bathymetry alone.
+        """
+        try:
+            self.bathymetry  # populates self.m6f_bathymetry if not already set
+        except FileNotFoundError:
+            print(
+                "NOTE: skipping boundary-orientation validation -- no bathymetry yet "
+                "(run setup_bathymetry first to enable this check)."
+            )
+            return
+
+        mask = self.m6f_bathymetry.supergridmask
+
+        for boundary in self.boundaries:
+            if not isinstance(boundary, Segment):
+                continue  # cardinal boundaries are always correct by construction
+
+            spec = boundary.to_spec()
+            axis, index, reverse = (
+                spec["axis"],
+                spec["index"],
+                spec["mom6_index_reverse"],
+            )
+            parallel_axis = "nxp" if axis == "nyp" else "nyp"
+            parallel_slice = (
+                slice(*spec["index_range"])
+                if spec["index_range"] is not None
+                else slice(None)
+            )
+
+            size = self.hgrid.sizes[axis]
+            resolved_index = index if index >= 0 else size + index
+
+            def ocean_fraction(
+                neighbor_index, size=size, parallel_slice=parallel_slice
+            ):
+                if neighbor_index < 0 or neighbor_index >= size:
+                    return None  # off the grid -- not a real "side"
+                return float(
+                    mask.isel(
+                        {axis: neighbor_index, parallel_axis: parallel_slice}
+                    ).mean()
+                )
+
+            low = ocean_fraction(resolved_index - 2)  # smaller-index (south/west) side
+            high = ocean_fraction(resolved_index + 2)  # larger-index (north/east) side
+
+            # Decide which side is the interior, only when unambiguous: one side
+            # entirely off-grid (the other side is interior by elimination), or one
+            # side entirely land and the other with some ocean.
+            if low is None and high is not None:
+                interior_is_high = True
+            elif high is None and low is not None:
+                interior_is_high = False
+            elif low is not None and high is not None and (low == 0) != (high == 0):
+                interior_is_high = high > 0
+            else:
+                continue  # both open ocean, both land, or both off-grid -- ambiguous
+
+            # axis "nyp" (line runs east-west): interior on the low (south) side -> reverse=True.
+            # axis "nxp" (line runs north-south): interior on the high (east) side -> reverse=True.
+            expected_reverse = (
+                not interior_is_high if axis == "nyp" else interior_is_high
+            )
+
+            if reverse != expected_reverse:
+                raise ValueError(
+                    f"Boundary '{boundary.segment_name}' has the wrong along-segment "
+                    f"direction: based on the bathymetry, its interior (ocean) side "
+                    f"implies mom6_index_reverse={expected_reverse}, but it was built "
+                    f"with mom6_index_reverse={reverse}. Per MOM6's OBC convention "
+                    "(https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions), "
+                    "segments must be indexed so the domain interior stays on the left "
+                    "walking counter-clockwise around the perimeter -- rebuild this "
+                    f"Segment with mom6_index_reverse={expected_reverse}."
+                )
 
     def _make_hgrid(self):
         """
@@ -1269,9 +1367,11 @@ class experiment:
         fill_method=None,
     ):
         """
-        A wrapper for :func:`~setup_single_boundary`. Given a list of up to four cardinal directions,
-        it creates a boundary forcing file for each one. Ensure that the raw boundaries are all saved
-        in the same directory, and that they are named using the format ``east_unprocessed.nc``.
+        A wrapper for :func:`~setup_single_boundary`. Given ``self.boundaries`` (cardinal
+        direction strings and/or interior/partial-edge ``Segment`` instances), creates a boundary
+        forcing file for each one. Ensure that the raw boundaries are all saved in the same
+        directory: named ``east_unprocessed.nc`` for a cardinal boundary, or
+        ``{segment.segment_name}_unprocessed.nc`` for a ``Segment`` boundary.
 
         Arguments:
             raw_boundaries_path (str): Path to the directory containing the raw boundary forcing files.
@@ -1279,8 +1379,6 @@ class experiment:
                 input dataset.
             bgc_tracer_names (Dict[str, str]): Specify the BGC tracer names to the name in the
                 input dataset, can also be specified in the varnames dict but this is here so we can reformat the output into seperate files. For example, ``{'oxygen': 'o2', 'phosphate': 'po4', ...}``.
-            boundaries (List[str]): List of cardinal directions for which to create boundary forcing files.
-                Default is ``["south", "north", "west", "east"]``.
             arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
@@ -1292,23 +1390,6 @@ class experiment:
             regridding_method = self.regridding_method
         if fill_method is None:
             fill_method = self.fill_method
-        for i in self.boundaries:
-            if i not in ["south", "north", "west", "east"]:
-                raise ValueError(
-                    f"Invalid boundary direction: {i}. Must be one of ['south', 'north', 'west', 'east']"
-                )
-
-        if len(self.boundaries) < 4:
-            print(
-                "NOTE: the 'setup_run_directories' method does understand the less than four boundaries but be careful. Please check the MOM_input/override file carefully to reflect the number of boundaries you have, and their orientations. You should be able to find the relevant section in the MOM_input/override file by searching for 'segment_'. Ensure that the segment names match those in your inputdir/forcing folder"
-            )
-
-        if len(self.boundaries) > 4:
-            raise ValueError(
-                "This method only supports up to four boundaries. To set up more complex boundary shapes, construct a "
-                "regional_mom6.segment.Segment directly (e.g. via Segment.from_hgrid) and call its "
-                "regrid_velocity_tracers method for each boundary."
-            )
 
         if bgc_tracer_names is None:
             bgc_tracer_names = {}
@@ -1322,15 +1403,17 @@ class experiment:
             key = "tracers" if "tracers" in physical_varnames else "tracer_var_names"
             all_varnames[key] = {**physical_varnames[key], **bgc_tracer_names}
 
-        # Now iterate through our four boundaries
-        for orientation in self.boundaries:
+        for boundary in self.boundaries:
+            # Raw file is named after the boundary's own identity (cardinal direction, or the
+            # segment_name the caller gave their Segment) -- independent of its position/number
+            # in self.boundaries.
+            raw_file_stem = (
+                boundary.segment_name if isinstance(boundary, Segment) else boundary
+            )
             self.setup_single_boundary(
-                Path(raw_boundaries_path / (orientation + "_unprocessed.nc")),
+                Path(raw_boundaries_path / (raw_file_stem + "_unprocessed.nc")),
                 all_varnames,
-                orientation,  # The cardinal direction of the boundary
-                self.find_MOM6_rectangular_orientation(
-                    orientation
-                ),  # A number to identify the boundary; indexes from 1
+                boundary,
                 arakawa_grid=arakawa_grid,
                 bathymetry_path=bathymetry_path,
                 regridding_method=regridding_method,
@@ -1354,8 +1437,8 @@ class experiment:
 
         # Read in the forcing datasets
         datasets = {}
-        for boundary in self.boundaries:
-            num = str(self.find_MOM6_rectangular_orientation(boundary)).zfill(3)
+        for i, boundary in enumerate(self.boundaries, start=1):
+            num = f"{i:03d}"
             datasets[num] = xr.open_dataset(
                 self.mom_input_dir / f"forcing_obc_segment_{num}.nc"
             )
@@ -1378,15 +1461,14 @@ class experiment:
         self,
         path_to_bc,
         varnames,
-        orientation,
-        segment_number,
+        boundary,
         arakawa_grid="A",
         bathymetry_path=None,
         regridding_method=None,
         fill_method=None,
     ):
         """
-        Set up a boundary forcing file for a given ``orientation``.
+        Set up a boundary forcing file for a given ``boundary``.
 
         Arguments:
             path_to_bc (str): Path to boundary forcing file. Ideally this should be a pre cut-out
@@ -1395,10 +1477,9 @@ class experiment:
                 will be slower.
             varnames (Dict[str, str]): Mapping from MOM6 variable/coordinate names to the name in the
                 input dataset.
-            orientation (str): Orientation of boundary forcing file, i.e., ``'east'``, ``'west'``,
-                ``'north'``, or ``'south'``.
-            segment_number (int): Number the segments according to how they'll be specified in
-                the ``MOM_input``.
+            boundary (Union[str, Segment]): The boundary to process -- a cardinal direction string
+                (``'east'``, ``'west'``, ``'north'``, or ``'south'``), or an interior/partial-edge
+                :class:`~regional_mom6.segment.Segment`.
             arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
@@ -1412,14 +1493,12 @@ class experiment:
         if fill_method is None:
             fill_method = self.fill_method
 
-        print(
-            "Processing {} boundary velocity & tracers...".format(orientation), end=""
-        )
+        print("Processing {} boundary velocity & tracers...".format(boundary), end="")
         if not Path(path_to_bc).exists():
             raise FileNotFoundError(
                 f"Boundary file not found at {path_to_bc}. Please ensure that the files are named in the format `east_unprocessed.nc`."
             )
-        segment = self._get_segment(orientation, bathymetry_path=bathymetry_path)
+        segment = self._get_segment(boundary, bathymetry_path=bathymetry_path)
 
         segment.regrid_velocity_tracers(
             infile=path_to_bc,  # location of raw boundary
@@ -1526,7 +1605,8 @@ class experiment:
         )
         # Initialize or find boundary segment
         for b in self.boundaries:
-            print("Processing {} boundary...".format(b), end="")
+            label = b.segment_name if isinstance(b, Segment) else b
+            print("Processing {} boundary...".format(label), end="")
 
             # If ocean-state setup already built this segment, reuse it instead of
             # re-deriving it from the grid again.
@@ -1750,6 +1830,8 @@ class experiment:
                     "No files with 'tu' in their names found in the forcing or input directory. If you meant to use tides, please run the setup_boundary_tides method first to create tidal files. If you didn't, set ``tidal_constituants = []`` when defining experiment."
                 )
 
+        self._validate_boundary_orientations()
+
         ### Make symlinks between run and input directories ###
         inputdir_in_rundir = self.mom_run_dir / "inputdir"
         rundir_in_inputdir = self.mom_input_dir / "rundir"
@@ -1797,9 +1879,9 @@ class experiment:
         MOM_override_dict["BRUSHCUTTER_MODE"]["value"] = "True"
 
         # Define Specific Segments
-        for seg in self.boundaries:
-            ind_seg = self.find_MOM6_rectangular_orientation(seg)
-            key_start = f"OBC_SEGMENT_00{ind_seg}"
+        for ind_seg, seg in enumerate(self.boundaries, start=1):
+            file_num_obc = f"{ind_seg:03d}"  # "001", "002", ... (up to 3 digits)
+            key_start = f"OBC_SEGMENT_{file_num_obc}"
             ## Position and Config
             key_POSITION = key_start
 
@@ -1815,26 +1897,23 @@ class experiment:
 
             # Data Key
             key_DATA = key_start + "_DATA"
-            file_num_obc = str(
-                self.find_MOM6_rectangular_orientation(seg)
-            )  # 1,2,3,4 for rectangular boundaries, BUT if we have less than 4 segments we use the index to specific the number, but keep filenames as if we had four boundaries
 
             obc_string = (
-                f'"U=file:forcing_obc_segment_00{file_num_obc}.nc(u),'
-                f"V=file:forcing_obc_segment_00{file_num_obc}.nc(v),"
-                f"SSH=file:forcing_obc_segment_00{file_num_obc}.nc(eta),"
-                f"TEMP=file:forcing_obc_segment_00{file_num_obc}.nc(temp),"
-                f"SALT=file:forcing_obc_segment_00{file_num_obc}.nc(salt)"
+                f'"U=file:forcing_obc_segment_{file_num_obc}.nc(u),'
+                f"V=file:forcing_obc_segment_{file_num_obc}.nc(v),"
+                f"SSH=file:forcing_obc_segment_{file_num_obc}.nc(eta),"
+                f"TEMP=file:forcing_obc_segment_{file_num_obc}.nc(temp),"
+                f"SALT=file:forcing_obc_segment_{file_num_obc}.nc(salt)"
             )
             MOM_override_dict[key_DATA]["value"] = obc_string
             if with_tides:
                 tides_addition = (
-                    f",Uamp=file:tu_segment_00{file_num_obc}.nc(uamp),"
-                    f"Uphase=file:tu_segment_00{file_num_obc}.nc(uphase),"
-                    f"Vamp=file:tu_segment_00{file_num_obc}.nc(vamp),"
-                    f"Vphase=file:tu_segment_00{file_num_obc}.nc(vphase),"
-                    f"SSHamp=file:tz_segment_00{file_num_obc}.nc(zamp),"
-                    f'SSHphase=file:tz_segment_00{file_num_obc}.nc(zphase)"'
+                    f",Uamp=file:tu_segment_{file_num_obc}.nc(uamp),"
+                    f"Uphase=file:tu_segment_{file_num_obc}.nc(uphase),"
+                    f"Vamp=file:tu_segment_{file_num_obc}.nc(vamp),"
+                    f"Vphase=file:tu_segment_{file_num_obc}.nc(vphase),"
+                    f"SSHamp=file:tz_segment_{file_num_obc}.nc(zamp),"
+                    f'SSHphase=file:tz_segment_{file_num_obc}.nc(zphase)"'
                 )
                 MOM_override_dict[key_DATA]["value"] = (
                     MOM_override_dict[key_DATA]["value"] + tides_addition

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -22,6 +22,7 @@ from regional_mom6.config import Config
 from regional_mom6.grid import Grid
 from regional_mom6.vgrid import VGrid
 from regional_mom6.topo import Topo
+from regional_mom6.boundary import Boundary
 from regional_mom6.utils import (
     ap2ep,
     ep2ap,
@@ -41,7 +42,7 @@ warnings.filterwarnings("ignore")
 
 __all__ = [
     "experiment",
-    "segment",
+    "Boundary",
     "get_glorys_data",
     "RotationMethod",
     "get_rotation_angle",
@@ -49,8 +50,9 @@ __all__ = [
 
 
 class RotationMethod(Enum):
-    """Prescribes the rotational method used in boundary conditions when the grid
-    does not have coordinates along lines of constant longitude-latitude.
+    """Prescribes the rotational method used to rotate whole-grid velocities
+    (e.g. for initial conditions) when the grid does not have coordinates along
+    lines of constant longitude-latitude.
 
     Attributes:
         EXPAND_GRID (int): Finds angles at q/u/v points by expanding the hgrid by one
@@ -65,61 +67,37 @@ class RotationMethod(Enum):
 
 
 def get_rotation_angle(
-    rotational_method: RotationMethod, hgrid: xr.Dataset, orientation=None
+    rotational_method: RotationMethod, hgrid: xr.Dataset
 ) -> xr.DataArray:
-    """Return the rotation angle (degrees) for the hgrid or a boundary slice of it.
+    """Return the rotation angle (degrees) for the whole hgrid.
+
+    Note: boundary segments no longer use this function -- ``Boundary`` reads
+    ``hgrid["angle_dx"]`` directly. This remains for whole-grid uses, e.g.
+    :func:`~experiment.setup_initial_condition`.
 
     Parameters
     ----------
     rotational_method : RotationMethod
     hgrid : xr.Dataset
-    orientation : str, optional
-        If given (e.g. ``"north"``), return only the boundary slice.
     """
-    boundary = orientation is not None
-
     if rotational_method == RotationMethod.NO_ROTATION:
         if not is_rectilinear_hgrid(hgrid):
             raise ValueError("NO_ROTATION method only works with rectilinear grids")
-        angles = xr.zeros_like(hgrid.x)
-        if boundary:
-            hgrid["zero_angle"] = angles
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="zero_angle"
-            )["angle"]
-        return angles
+        return xr.zeros_like(hgrid.x)
 
     elif rotational_method == RotationMethod.GIVEN_ANGLE:
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
-            )["angle"]
         return hgrid["angle_dx"]
 
     elif rotational_method == RotationMethod.EXPAND_GRID:
-        hgrid["angle_dx_rm6"] = xr.DataArray(
+        return xr.DataArray(
             SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
                 hgrid.x.values, hgrid.y.values
             ),
             dims=hgrid.x.dims,
         )
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx_rm6"
-            )["angle"]
-        return hgrid["angle_dx_rm6"]
 
     raise ValueError("Invalid rotational method")
 
-
-# If the array is pint possible, ensure we have the right units for main fields (eta, u, v, temp),
-# salinity and bgc tracers are a bit more abstract and should be already in the correct units, a TODO: would be to add functionality to convert these tracers
-main_field_target_units = {
-    "eta": "m",
-    "u": "m/s",
-    "v": "m/s",
-    "temp": "degC",
-}
 
 ## Mapping Functions
 
@@ -680,6 +658,41 @@ class experiment:
             )
         return val
 
+    def _get_boundary(self, orientation, bathymetry_path=None):
+        """
+        Build (or reuse a cached) :class:`~regional_mom6.boundary.Boundary` for the
+        given cardinal ``orientation``.
+
+        The first call for a given ``orientation`` builds the ``Boundary`` (masking
+        with the bathymetry at ``bathymetry_path`` if given) and caches it in
+        ``self.segments``; subsequent calls for the same ``orientation`` reuse the
+        cached ``Boundary`` regardless of ``bathymetry_path`` -- this lets
+        :func:`~setup_ocean_state_boundaries` and :func:`~setup_boundary_tides` share
+        one ``Boundary`` per orientation instead of each re-deriving it from the grid.
+        """
+        if orientation in self.segments:
+            return self.segments[orientation]
+
+        topo = None
+        if bathymetry_path is not None:
+            try:
+                self.hgrid  # ensures `m6f_hgrid` is populated (from disk if needed)
+                topo = Topo.from_topo_file(
+                    self.m6f_hgrid,
+                    bathymetry_path,
+                    min_depth=self.minimum_depth,
+                    git=False,
+                )
+            except Exception:
+                topo = None
+
+        segment_name = "segment_{:03d}".format(
+            self.find_MOM6_rectangular_orientation(orientation)
+        )
+        boundary = Boundary.cardinal(self.hgrid, orientation, segment_name, topo=topo)
+        self.segments[orientation] = boundary
+        return boundary
+
     def _make_hgrid(self):
         """
         Set up a horizontal grid based on user's specification of the domain.
@@ -785,7 +798,7 @@ class experiment:
         if regridding_method is None:
             regridding_method = self.regridding_method
 
-        reprocessed_var_map = apply_arakawa_grid_mapping(
+        reprocessed_var_map = rgd.apply_arakawa_grid_mapping(
             var_mapping=varnames, arakawa_grid=arakawa_grid
         )
 
@@ -807,13 +820,13 @@ class experiment:
         )
 
         # Convert values
-        for var in main_field_target_units:
+        for var in rgd.main_field_target_units:
             if var == "temp" or var == "salt":
                 value_name = reprocessed_var_map["tracer_var_names"][var]
             else:
                 value_name = reprocessed_var_map[var + "_var_name"]
             ic_raw[value_name] = try_pint_convert(
-                ic_raw[value_name], main_field_target_units[var], var
+                ic_raw[value_name], rgd.main_field_target_units[var], var
             )
         # Remove time dimension if present in the IC.
         # Assume that the first time dim is the intended one if more than one is present
@@ -1234,7 +1247,6 @@ class experiment:
         bgc_tracer_names: dict = None,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1255,8 +1267,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
                 boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is ``EXPAND_GRID``.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
         """
@@ -1277,7 +1287,9 @@ class experiment:
 
         if len(self.boundaries) > 4:
             raise ValueError(
-                "This method only supports up to four boundaries. To set up more complex boundary shapes you can manually call the 'simple_boundary' method for each boundary."
+                "This method only supports up to four boundaries. To set up more complex boundary shapes, construct a "
+                "regional_mom6.boundary.Boundary directly (e.g. via Boundary.from_hgrid) and call its "
+                "regrid_velocity_tracers method for each boundary."
             )
 
         if bgc_tracer_names is None:
@@ -1303,7 +1315,6 @@ class experiment:
                 ),  # A number to identify the boundary; indexes from 1
                 arakawa_grid=arakawa_grid,
                 bathymetry_path=bathymetry_path,
-                rotational_method=rotational_method,
                 regridding_method=regridding_method,
                 fill_method=fill_method,
             )
@@ -1353,7 +1364,6 @@ class experiment:
         segment_number,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1375,8 +1385,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
                 the boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
 
@@ -1393,23 +1401,17 @@ class experiment:
             raise FileNotFoundError(
                 f"Boundary file not found at {path_to_bc}. Please ensure that the files are named in the format `east_unprocessed.nc`."
             )
-        self.segments[orientation] = segment(
-            hgrid=self.hgrid,
-            bathymetry_path=bathymetry_path,
-            outfolder=self.mom_input_dir,
-            segment_name="segment_{:03d}".format(segment_number),
-            orientation=orientation,  # orienataion
-            startdate=self.date_range[0],
-            repeat_year_forcing=self.repeat_year_forcing,
-        )
+        boundary = self._get_boundary(orientation, bathymetry_path=bathymetry_path)
 
-        self.segments[orientation].regrid_velocity_tracers(
+        boundary.regrid_velocity_tracers(
             infile=path_to_bc,  # location of raw boundary
             varnames=varnames,
+            outfolder=self.mom_input_dir,
+            startdate=self.date_range[0],
             arakawa_grid=arakawa_grid,
-            rotational_method=rotational_method,
             regridding_method=regridding_method,
             fill_method=fill_method,
+            repeat_year_forcing=self.repeat_year_forcing,
         )
 
         print("Done.")
@@ -1421,7 +1423,6 @@ class experiment:
         tpxo_velocity_filepath,
         tidal_constituents=None,
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1434,7 +1435,6 @@ class experiment:
             tpxo_velocity_filepath: Filepath to the TPXO velocity product. Generally of the form ``u_tidalversion.nc``
             tidal_constituents: List of tidal constituents to include in the regridding. Default is set in the experiment constructor (See :class:`~Experiment`)
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case the boundary condition is not masked
-            rotational_method (str): Method to use for rotating the tidal velocities. Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
 
@@ -1443,11 +1443,11 @@ class experiment:
 
         The tidal data functions are sourced from the GFDL NWA25 and modified so that:
 
-        - Converted code for regional-mom6 :func:`segment` class
+        - Converted code for regional-mom6 :class:`~regional_mom6.boundary.Boundary` class
         - Implemented horizontal subsetting.
         - Combined all functions of NWA25 into a four function process (in the style of regional-mom6), i.e.,
-          :func:`~experiment.setup_boundary_tides`, :func:`~regional_mom6.regridding.coords`, :func:`segment.regrid_tides`, and
-          :func:`segment.encode_tidal_files_and_output`.
+          :func:`~experiment.setup_boundary_tides`, :meth:`Boundary.from_hgrid`, :meth:`Boundary.regrid_tides`, and
+          :meth:`Boundary.encode_tidal_files_and_output`.
 
         Code credit:
 
@@ -1510,27 +1510,20 @@ class experiment:
         for b in self.boundaries:
             print("Processing {} boundary...".format(b), end="")
 
-            # If the GLORYS ocean_state has already created segments, we don't create them again.
-            seg = segment(
-                hgrid=self.hgrid,
-                bathymetry_path=bathymetry_path,
-                outfolder=self.mom_input_dir,
-                segment_name="segment_{:03d}".format(
-                    self.find_MOM6_rectangular_orientation(b)
-                ),
-                orientation=b,
-                startdate=self.date_range[0],
-                repeat_year_forcing=self.repeat_year_forcing,
-            )
+            # If ocean-state setup already built this boundary, reuse it instead of
+            # re-deriving it from the grid again.
+            boundary = self._get_boundary(b, bathymetry_path=bathymetry_path)
 
             # Output and regrid tides
-            seg.regrid_tides(
+            boundary.regrid_tides(
                 tpxo_v,
                 tpxo_u,
                 tpxo_h,
                 times,
-                rotational_method=rotational_method,
+                outfolder=self.mom_input_dir,
+                startdate=self.date_range[0],
                 regridding_method=regridding_method,
+                repeat_year_forcing=self.repeat_year_forcing,
             )
             print("Done")
 
@@ -2146,931 +2139,3 @@ class experiment:
                     unlimited_dims="time",
                     encoding={vname: {"dtype": "double"}},
                 )
-
-
-class segment:
-    """
-    Class to turn raw boundary and tidal segment data into MOM6 boundary
-    and tidal segments.
-
-    Boundary segments should only contain the necessary data for that
-    segment. No horizontal chunking is done here, so big fat segments
-    will process slowly.
-
-    Data should be at daily temporal resolution, iterating upwards
-    from the provided startdate. Function ignores the time metadata
-    and puts it on gregorian calendar.
-
-    Note:
-        Only supports z-star (z*) vertical coordinate.
-
-    Arguments:
-        hgrid (xarray.Dataset): The horizontal grid used for domain.
-
-        outfolder (Union[str, Path]): Path to folder where the model inputs will
-            be stored.
-        segment_name (str): Name of the segment, e.g., ``'segment_001'``.
-        orientation (str): Cardinal direction (lowercase) of the boundary segment,
-            i.e., ``'east'``, ``'west'``, ``'north'``, or ``'south'``.
-        startdate (str): The starting date to use in the segment calendar.
-        time_units (str): The units used by the raw forcing files, e.g., ``hours``,
-            ``days`` (default).
-        repeat_year_forcing (Optional[bool]): When ``True`` the experiment runs with repeat-year
-            forcing. When ``False`` (default) then inter-annual forcing is used.
-    """
-
-    def __init__(
-        self,
-        *,
-        hgrid,
-        outfolder,
-        segment_name,
-        orientation,
-        startdate,
-        bathymetry_path=None,
-        repeat_year_forcing=False,
-    ):
-        self.startdate = startdate
-
-        ## Store other data
-        orientation = orientation.lower()
-        if orientation not in ("north", "south", "east", "west"):
-            raise ValueError(
-                "orientation only supported for one of: 'north', 'south', 'east', or 'west'. If you are using a non-rectangular grid, please modify the code accordingly."
-            )
-        self.orientation = orientation
-        self.outfolder = outfolder
-        self.hgrid = hgrid
-        try:
-            self.bathymetry = xr.open_dataset(bathymetry_path)
-        except:
-            self.bathymetry = None
-        self.segment_name = segment_name
-        self.repeat_year_forcing = repeat_year_forcing
-        self.regridders = None
-        self.tidal_regridders = None
-
-    def regrid_velocity_tracers(
-        self,
-        infile,
-        varnames: dict,
-        arakawa_grid="A",
-        rotational_method=RotationMethod.EXPAND_GRID,
-        regridding_method="bilinear",
-        time_units="days",
-        calendar="gregorian",
-        fill_method=rgd.fill_missing_data,
-        regridders=None,
-    ):
-        """
-        Cut out and interpolate the velocities and tracers.
-
-        Arguments:
-            rotational_method (RotationMethod): The method to use for rotation of the velocities. Currently, the default method, ``EXPAND_GRID``, works even with non-rotated grids.
-            infile (Union[str, Path]): Path to the raw, unprocessed boundary segment.
-            varnames (Dict[str, str]): Mapping between the variable/dimension names and
-            standard naming convention of this pipeline, e.g., ``{"xq": "longitude,
-            "yh": "latitude", "salt": "salinity", ...}``. Key "tracers" points to nested
-            dictionary of tracers to include in boundary.
-            arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
-                Either ``'A'`` (default), ``'B'``, or ``'C'``.
-            regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
-            fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
-            regridders (dict, optional): Pre-built regridders with keys ``"tracers"``, ``"u"``, ``"v"``.
-                If provided, regridder creation is skipped entirely — useful when calling this method
-                multiple times for different time windows on the same grid (pass ``seg.regridders``
-                from a prior call). Default ``None`` — regridders are built and saved to
-                ``self.regridders``.
-
-        """
-        reprocessed_var_map = apply_arakawa_grid_mapping(
-            var_mapping=varnames, arakawa_grid=arakawa_grid
-        )
-
-        # Create weights directory
-        (self.outfolder / "weights").mkdir(exist_ok=True)
-
-        rawseg = xr.open_mfdataset(infile, decode_times=False, engine="netcdf4")
-
-        coords = rgd.coords(self.hgrid, self.orientation, self.segment_name)
-
-        # Convert z coordinates to meters if pint-enabled
-        if type(reprocessed_var_map["depth_coord"]) != list:
-            dc_list = [reprocessed_var_map["depth_coord"]]
-        else:
-            dc_list = reprocessed_var_map["depth_coord"]
-        for dc in dc_list:
-            rawseg[dc] = try_pint_convert(rawseg[dc], "m", dc)
-
-        if regridders is None:
-            regridders = create_vt_regridders(
-                reprocessed_var_map,
-                rawseg,
-                coords,
-                Path(self.outfolder),
-                regridding_method,
-                self.orientation,
-            )
-        self.regridders = regridders
-
-        u_regridded = regridders["u"](
-            rawseg[reprocessed_var_map["u_var_name"]].rename(
-                {
-                    reprocessed_var_map["u_x_coord"]: "lon",
-                    reprocessed_var_map["u_y_coord"]: "lat",
-                }
-            )
-        )
-        v_regridded = regridders["v"](
-            rawseg[reprocessed_var_map["v_var_name"]].rename(
-                {
-                    reprocessed_var_map["v_x_coord"]: "lon",
-                    reprocessed_var_map["v_y_coord"]: "lat",
-                }
-            )
-        )
-        tracers_regridded = regridders["tracers"](
-            rawseg[
-                [reprocessed_var_map["eta_var_name"]]
-                + list(reprocessed_var_map["tracer_var_names"].values())
-            ].rename(
-                {
-                    reprocessed_var_map["tracer_x_coord"]: "lon",
-                    reprocessed_var_map["tracer_y_coord"]: "lat",
-                }
-            )
-        )
-
-        rotated_u, rotated_v = rotate(
-            u_regridded,
-            v_regridded,
-            radian_angle=np.radians(
-                get_rotation_angle(
-                    rotational_method, self.hgrid, orientation=self.orientation
-                ).values
-            ),
-        )
-
-        rotated_u.name = reprocessed_var_map["u_var_name"]
-        rotated_v.name = reprocessed_var_map["v_var_name"]
-        segment_out = xr.merge([rotated_u, rotated_v, tracers_regridded])
-
-        ## segment out now contains our interpolated boundary.
-        ## Now, we need to fix up all the metadata and save
-        segment_out = segment_out.rename(
-            {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
-        )
-
-        ## Convert temperatures to celsius # use pint
-        depth_coord = reprocessed_var_map["depth_coord"]
-        if type(reprocessed_var_map["depth_coord"]) == list:
-            for dc in reprocessed_var_map["depth_coord"]:
-                if (
-                    dc
-                    in segment_out[reprocessed_var_map["tracer_var_names"]["temp"]].dims
-                ):  # At least one must be true
-                    depth_coord = dc
-
-        if "since" not in time_units:
-            times = xr.DataArray(
-                np.arange(
-                    0,  #! Indexing everything from start of experiment = simple but maybe counterintutive?
-                    segment_out[reprocessed_var_map["time_var_name"]].shape[
-                        0
-                    ],  ## Time is indexed from start date of window
-                    dtype=float,
-                ),  # Import pandas for this shouldn't be a big deal b/c it's already kinda required somewhere deep in some tree.
-                dims=["time"],
-            )
-
-            # This to change the time coordinate.
-            segment_out = rgd.add_or_update_time_dim(
-                segment_out, times, reprocessed_var_map["depth_coord"]
-            )
-
-            segment_out.time.attrs = {
-                "calendar": calendar,
-                "units": f"{time_units} since {self.startdate}",
-            }
-        else:
-            segment_out.time.attrs = {
-                "calendar": calendar,
-                "units": time_units,
-            }
-
-        # Here, keep in mind that 'var' keeps track of the mom6 variable names we want, and self.tracers[var]
-        # will return the name of the variable from the original data
-        output_var_list = []
-        allfields = {
-            **reprocessed_var_map["tracer_var_names"],
-            "u": reprocessed_var_map["u_var_name"],
-            "v": reprocessed_var_map["v_var_name"],
-            "eta": reprocessed_var_map["eta_var_name"],
-        }  ## Combine all fields into one flattened dictionary to iterate over as we fix metadata
-
-        for (
-            var
-        ) in (
-            allfields
-        ):  ## Replace with more generic list of tracer variables that might be included?
-            v = f"{var}_{self.segment_name}"
-            ## Rename each variable in dataset
-            segment_out = segment_out.rename({allfields[var]: v})
-            output_var_list.append(v)
-
-            # Try Pint Conversion
-            if var in main_field_target_units:
-                # Apply raw data units if they exist
-                units = rawseg[allfields[var]].attrs.get("units")
-                if units is not None:
-                    segment_out[v].attrs["units"] = units
-
-                segment_out[v] = try_pint_convert(
-                    segment_out[v], main_field_target_units[var], var
-                )
-
-            # Find out if the tracer has depth, and if so, what is it's z dimension (z dimension being a list is an edge case for MARBL BGC)
-            variable_has_depth = False
-            depth_coord = None
-            if type(reprocessed_var_map["depth_coord"]) != list:
-                dc_list = [reprocessed_var_map["depth_coord"]]
-            else:
-                dc_list = reprocessed_var_map["depth_coord"]
-
-            for dc in dc_list:
-                if dc in segment_out[v].dims:
-                    depth_coord = dc
-                    variable_has_depth = True
-                    break
-
-            if variable_has_depth:
-                segment_out = rgd.vertical_coordinate_encoding(
-                    segment_out,
-                    v,
-                    self.segment_name,
-                    depth_coord,
-                )
-
-            segment_out = rgd.add_secondary_dimension(
-                segment_out, v, coords, self.segment_name
-            )
-            if variable_has_depth:
-                segment_out = rgd.generate_layer_thickness(
-                    segment_out,
-                    v,
-                    self.segment_name,
-                    depth_coord,
-                )
-
-        # Here, do a foolproof (hopefully) manual conversion from K -> C just in case
-        # pint doesn't manage to do so. Pint is finicky, but required for BGC fields. However,
-        # we're making sure that temp will always be in C not K as this is a big problem!
-        if (
-            np.nanmin(
-                segment_out[f"temp_{self.segment_name}"].isel(
-                    {
-                        reprocessed_var_map["time_var_name"]: 0,
-                        f"nz_{self.segment_name}_temp": 0,
-                    }
-                )
-            )
-            > 100
-        ):
-            segment_out[f"temp_{self.segment_name}"] -= 273.15
-            segment_out[f"temp_{self.segment_name}"].attrs["units"] = "degrees Celsius"
-
-        # fill in NaNs
-        segment_out = fill_method(
-            segment_out,
-            xdim=f"{coords.attrs['parallel']}_{self.segment_name}",
-            zdim=reprocessed_var_map["depth_coord"],
-        )
-
-        # Overwrite the actual lat/lon values in the dimensions, replace with incrementing integers
-        segment_out[f"{coords.attrs['perpendicular']}_{self.segment_name}"] = [0]
-
-        segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"] = np.arange(
-            segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"].size
-        )
-        segment_out[f"ny_{self.segment_name}"].attrs["axis"] = "Y"
-        segment_out[f"nx_{self.segment_name}"].attrs["axis"] = "X"
-        encoding_dict = {
-            "time": {"dtype": "double"},
-            f"nx_{self.segment_name}": {
-                "dtype": "int32",
-            },
-            f"ny_{self.segment_name}": {
-                "dtype": "int32",
-            },
-        }
-        segment_out = rgd.mask_dataset(
-            segment_out,
-            self.bathymetry,
-            self.orientation,
-        )
-        encoding_dict = rgd.generate_encoding(
-            segment_out,
-            encoding_dict,
-            default_fill_value=1.0e20,
-        )
-        # If repeat-year forcing, add modulo coordinate
-        if self.repeat_year_forcing:
-            segment_out["time"] = segment_out["time"].assign_attrs({"modulo": " "})
-        segment_out.load().to_netcdf(
-            self.outfolder / f"forcing_obc_{self.segment_name}.nc",
-            encoding=encoding_dict,
-            unlimited_dims="time",
-        )
-
-        validate_obc_file(
-            segment_out,
-            output_var_list,
-            encoding_dict,
-            surface_var=f"eta_{self.segment_name}",
-        )
-
-        return segment_out, encoding_dict
-
-    def regrid_tides(
-        self,
-        tpxo_v,
-        tpxo_u,
-        tpxo_h,
-        times,
-        rotational_method=RotationMethod.EXPAND_GRID,
-        regridding_method="bilinear",
-        fill_method=rgd.fill_missing_data,
-        regridders=None,
-    ):
-        """
-        Regrids and interpolates the tidal data for MOM6. Steps include:
-
-        - Read raw tidal data (all constituents)
-        - Perform minor transformations/conversions
-        - Regrid the tidal elevation, and tidal velocity
-        - Encode the output
-
-        General Description:
-            The tidal data functions sourced from the GFDL's code above were changed in the following ways:
-
-            - Converted code for regional-mom6 segment class
-            - Implemented horizontal subsetting
-            - Combined all functions of NWA25 into a four function process (in the style of regional-mom6), i.e.,
-              :func:`~experiment.setup_boundary_tides`, :func:`~regional_mom6.regridding.coords`, :func:`segment.regrid_tides`, and
-              :func:`segment.encode_tidal_files_and_output`.
-
-        Arguments:
-            infile_td (str): Raw tidal file/directory.
-            tpxo_v, tpxo_u, tpxo_h (xarray.Dataset): Specific adjusted for MOM6 tpxo datasets (Adjusted with :func:`~experiment.setup_boundary_tides`)
-            times (pd.DateRange): The start date of our model period.
-            rotational_method (RotationMethod): The method to use for rotation of the velocities.
-                The default method, ``EXPAND_GRID``, works even with non-rotated grids.
-            regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
-            fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
-            regridders (dict, optional): Pre-built regridders with keys ``"elev"``, ``"u"``, ``"v"``.
-                If provided, regridder creation is skipped entirely — useful when calling this method
-                multiple times on the same grid (pass ``seg.tidal_regridders`` from a prior call).
-                Default ``None`` — regridders are built and saved to ``self.tidal_regridders``.
-
-        Returns:
-            netCDF files: Regridded tidal velocity and elevation files in 'inputdir/forcing'
-
-        Code credit:
-
-        .. code-block:: bash
-
-            Author(s): GFDL, James Simkins, Rob Cermak, and contributors
-            Year: 2022
-            Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
-            Version: N/A
-            Type: Python Functions, Source Code
-            Web Address: https://github.com/jsimkins2/nwa25
-        """
-
-        # Create weights directory
-        (self.outfolder / "weights").mkdir(exist_ok=True)
-
-        # Establish Coords
-        coords = rgd.coords(self.hgrid, self.orientation, self.segment_name)
-
-        if regridders is None:
-            regridders = {
-                "elev": rgd.create_regridder(
-                    tpxo_h[["lon", "lat", "hRe"]],
-                    coords,
-                    self.outfolder
-                    / "weights"
-                    / f"bilinear_tidal_elev_weights_{self.segment_name}.nc",
-                    method=regridding_method,
-                ),
-                "u": rgd.create_regridder(
-                    tpxo_u[["lon", "lat", "uRe"]],
-                    coords,
-                    self.outfolder
-                    / "weights"
-                    / f"bilinear_tidal_u_weights_{self.segment_name}.nc",
-                    method=regridding_method,
-                ),
-                "v": rgd.create_regridder(
-                    tpxo_v[["lon", "lat", "vRe"]],
-                    coords,
-                    self.outfolder
-                    / "weights"
-                    / f"bilinear_tidal_v_weights_{self.segment_name}.nc",
-                    method=regridding_method,
-                ),
-            }
-        self.tidal_regridders = regridders
-        regrid = regridders["elev"]
-
-        ########## Tidal Elevation: Horizontally interpolate elevation components ############
-
-        redest = regrid(tpxo_h[["lon", "lat", "hRe"]])
-        imdest = regrid(tpxo_h[["lon", "lat", "hIm"]])
-
-        # Fill missing data.
-        # Need to do this first because complex would get converted to real
-        redest = fill_method(
-            redest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-        redest = redest["hRe"]
-        imdest = fill_method(
-            imdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-        imdest = imdest["hIm"]
-
-        # Convert complex
-        cplex = redest + 1j * imdest
-
-        # Convert to real amplitude and phase.
-        ds_ap = xr.Dataset({f"zamp_{self.segment_name}": np.abs(cplex)})
-
-        # np.angle doesn't return dataarray
-        ds_ap[f"zphase_{self.segment_name}"] = (
-            ("constituent", f"{coords.attrs['parallel']}_{self.segment_name}"),
-            -1 * np.angle(cplex),
-        )  # radians
-
-        # Add time coordinate and transpose so that time is first,
-        # so that it can be the unlimited dimension
-        times = xr.DataArray(
-            pd.date_range(
-                self.startdate, periods=1
-            ),  # Import pandas for this shouldn't be a big deal b/c it's already kinda required somewhere deep in some tree.
-            dims=["time"],
-        )
-
-        ds_ap = rgd.add_or_update_time_dim(ds_ap, times)
-        ds_ap = ds_ap.transpose(
-            "time", "constituent", f"{coords.attrs['parallel']}_{self.segment_name}"
-        )
-
-        self.encode_tidal_files_and_output(ds_ap, "tz")
-
-        ########### Regrid Tidal Velocity ######################
-
-        regrid_u = regridders["u"]
-        regrid_v = regridders["v"]
-
-        # Interpolate each real and imaginary parts to self.
-        uredest = regrid_u(tpxo_u[["lon", "lat", "uRe"]])["uRe"]
-        uimdest = regrid_u(tpxo_u[["lon", "lat", "uIm"]])["uIm"]
-        vredest = regrid_v(tpxo_v[["lon", "lat", "vRe"]])["vRe"]
-        vimdest = regrid_v(tpxo_v[["lon", "lat", "vIm"]])["vIm"]
-
-        # Fill missing data.
-        # Need to do this first because complex would get converted to real
-        uredest = fill_method(
-            uredest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-        uimdest = fill_method(
-            uimdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-        vredest = fill_method(
-            vredest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-        vimdest = fill_method(
-            vimdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-
-        # Convert to complex, remaining separate for u and v.
-        ucplex = uredest + 1j * uimdest
-        vcplex = vredest + 1j * vimdest
-
-        # Convert complex u and v to ellipse,
-        # rotate ellipse from earth-relative to model-relative,
-        # and convert ellipse back to amplitude and phase.
-        SEMA, ECC, INC, PHA = ap2ep(ucplex, vcplex)
-
-        # Rotate
-        INC -= np.radians(
-            get_rotation_angle(
-                rotational_method, self.hgrid, orientation=self.orientation
-            ).data[np.newaxis, :]
-        )
-
-        ua, va, up, vp = ep2ap(SEMA, ECC, INC, PHA)
-        # Convert to real amplitude and phase.
-
-        ds_ap = xr.Dataset(
-            {f"uamp_{self.segment_name}": ua, f"vamp_{self.segment_name}": va}
-        )
-        # up, vp aren't dataarraysf
-        ds_ap[f"uphase_{self.segment_name}"] = (
-            ("constituent", f"{coords.attrs['parallel']}_{self.segment_name}"),
-            up,
-        )  # radians
-        ds_ap[f"vphase_{self.segment_name}"] = (
-            ("constituent", f"{coords.attrs['parallel']}_{self.segment_name}"),
-            vp,
-        )  # radians
-
-        times = xr.DataArray(
-            pd.date_range(
-                self.startdate, periods=1
-            ),  # Import pandas for this shouldn't be a big deal b/c it's already kinda required somewhere deep in some tree.
-            dims=["time"],
-        )
-        ds_ap = rgd.add_or_update_time_dim(ds_ap, times)
-        ds_ap = ds_ap.transpose(
-            "time", "constituent", f"{coords.attrs['parallel']}_{self.segment_name}"
-        )
-
-        # Some things may have become missing during the transformation
-        ds_ap = fill_method(
-            ds_ap, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
-        )
-
-        self.encode_tidal_files_and_output(ds_ap, "tu")
-
-        return
-
-    def encode_tidal_files_and_output(self, ds, filename):
-        """
-        This method:
-
-        - Expands the dimensions (with the segment name)
-        - Renames some dimensions to be more specific to the segment
-        - Provides an output file encoding
-        - Exports the files.
-
-        Arguments:
-            self.outfolder (str/path): The output folder to save the tidal files into
-            dataset (xarray.Dataset): The processed tidal dataset
-            filename (str): The output file name
-
-        Returns:
-            netCDF files: Regridded [FILENAME] files in 'self.outfolder/[filename]_[segmentname].nc'
-
-        General Description:
-            This tidal data functions are sourced from the GFDL NWA25 and changed in the following ways:
-
-            - Converted code for regional-mom6 segment class
-            - Implemented horizontal Subsetting
-            - Combined all functions of NWA25 into a four function process (in the style of regional-mom6), i.e.,
-              :func:`~experiment.setup_boundary_tides`, :func:`~regional_mom6.regridding.coords`, :func:`segment.regrid_tides`, and
-              :func:`segment.encode_tidal_files_and_output`.
-
-        Code credit:
-
-        .. code-block:: bash
-
-            Author(s): GFDL, James Simkins, Rob Cermak, and contributors
-            Year: 2022
-            Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
-            Version: N/A
-            Type: Python Functions, Source Code
-            Web Address: https://github.com/jsimkins2/nwa25
-        """
-
-        coords = rgd.coords(self.hgrid, self.orientation, self.segment_name)
-
-        ## Expand Tidal Dimensions ##
-        output_var_list = []
-        for var in ds:
-            ds = rgd.add_secondary_dimension(ds, str(var), coords, self.segment_name)
-            output_var_list.append(var)
-
-        ## Rename Tidal Dimensions ##
-        ds = ds.rename(
-            {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
-        )
-
-        if self.bathymetry is not None:
-            print(
-                "Bathymetry has been provided to the regridding tides function. "
-                "Masking tides dataset with bathymetry may result in errors like large surface values one timestep in. "
-                " To avoid masking tides, do not pass in bathymetry path to the tides function."
-            )
-        ds = rgd.mask_dataset(ds, self.bathymetry, self.orientation)
-        ## Perform Encoding ##
-
-        fname = f"{filename}_{self.segment_name}.nc"
-        # Set format and attributes for coordinates, including time if it does not already have calendar attribute
-        # (may change this to detect whether time is a time type or a float).
-        # Need to include the fillvalue or it will be back to nan
-        encoding = {
-            "time": dict(dtype="float64", calendar="gregorian", _FillValue=1.0e20),
-            f"lon_{self.segment_name}": dict(dtype="float64", _FillValue=1.0e20),
-            f"lat_{self.segment_name}": dict(dtype="float64", _FillValue=1.0e20),
-        }
-        encoding = rgd.generate_encoding(ds, encoding, default_fill_value=1.0e20)
-
-        validate_obc_file(
-            ds,
-            output_var_list,
-            encoding,
-            surface_var="",
-        )
-
-        ## Export Files ##
-        ds.to_netcdf(
-            Path(self.outfolder / fname),
-            engine="netcdf4",
-            encoding=encoding,
-            unlimited_dims="time",
-        )
-        return ds
-
-
-def create_vt_regridders(
-    reprocessed_var_map: dict,
-    rawseg: xr.Dataset,
-    coords: xr.Dataset,
-    outfolder: str,
-    regridding_method: str,
-    id: str = "",
-) -> dict[str, xe.Regridder]:
-    """
-    Create regridders for velocity and tracer variables based on the specified Arakawa grid.
-
-    This function uses a validated variable mapping to create one or more
-    `xesmf.Regridder` objects for velocity (`u`, `v`) and tracer fields,
-    depending on the detected Arakawa grid type.
-
-    Args:
-        reprocessed_var_map: Mapping of variable and coordinate names, including nested
-            tracer variable names (e.g., {"tracers": {"salt": "salt", "temp": "temp"}}).
-        raw_seg: The source dataset containing the original variables.
-        coords: The target grid coordinates dataset.
-        outfolder: Path to the output folder where regridding weights are saved.
-        regridding_method: The interpolation method (default: "bilinear").
-        id: Optional string identifier appended to output weight filenames.
-
-    Returns:
-        dict[str, xe.Regridder]: A dictionary containing the created regridders with keys:
-            - "tracers"
-            - "u"
-            - "v"
-    """
-    regridders = {}
-    arakawa_grid = identify_arakawa_grid(reprocessed_var_map)
-    outfolder = Path(outfolder)
-    regridders["tracers"] = rgd.create_regridder(
-        rawseg[reprocessed_var_map["tracer_var_names"]["salt"]].rename(
-            {
-                reprocessed_var_map["tracer_lon_coord"]: "lon",
-                reprocessed_var_map["tracer_lat_coord"]: "lat",
-            }
-        ),
-        coords,
-        outfolder / f"weights/bilinear_tracer_weights_{id}.nc",
-        method=regridding_method,
-    )
-
-    if arakawa_grid == "B" or arakawa_grid == "C":
-        regridders["u"] = rgd.create_regridder(
-            rawseg[reprocessed_var_map["u_var_name"]].rename(
-                {
-                    reprocessed_var_map["u_lon_coord"]: "lon",
-                    reprocessed_var_map["u_lat_coord"]: "lat",
-                }
-            ),
-            coords,
-            outfolder / f"weights/bilinear_u_weights_{id}.nc",
-            method=regridding_method,
-        )
-    else:  # Arakawa A
-        regridders["u"] = regridders["tracers"]
-
-    if arakawa_grid == "C":
-        regridders["v"] = rgd.create_regridder(
-            rawseg[reprocessed_var_map["v_var_name"]].rename(
-                {
-                    reprocessed_var_map["v_lon_coord"]: "lon",
-                    reprocessed_var_map["v_lat_coord"]: "lat",
-                }
-            ),
-            coords,
-            outfolder / f"weights/bilinear_v_weights_{id}.nc",
-            method=regridding_method,
-        )
-    else:  # Arakawa A and B
-        regridders["v"] = regridders["u"]
-
-    return regridders
-
-
-def apply_arakawa_grid_mapping(var_mapping: dict, arakawa_grid: str = None) -> dict:
-    """
-    Map variable and coordinate names according to the specified Arakawa grid type.
-
-    This function checks the provided Arakawa grid type and constructs a consistent
-    mapping between standard variable keys (e.g., tracer, velocity components) and
-    their corresponding actual names. It raises an error if any required variable
-    names are missing for the specified grid type.
-
-    Args:
-        var_mappings (Dict[str, str]):
-            A dictionary mapping standardized variable/dimension names to their actual
-            names. Input names can use either the ``xh/xq`` convention with a specific arakawa grid or the exact output
-            format produced by this function without the arakawa_grid specified (which it will only then do the sanity checks).
-        arakawa_grid (str):
-            The Arakawa grid staggering type of the boundary forcing. Must be one of:
-            ``'A'``, ``'B'``, or ``'C'``.
-
-    Returns:
-        Dict[str, Any]:
-            A dictionary containing variable names mapped according to the specified
-            Arakawa grid type. The returned dictionary includes the following keys:
-                - ``u_x_coord``
-                - ``u_y_coord``
-                - ``v_x_coord``
-                - ``v_y_coord``
-                - ``tracer_x_coord``
-                - ``tracer_y_coord``
-                - ``u_lon_coord``
-                - ``u_lat_coord``
-                - ``v_lon_coord``
-                - ``v_lat_coord``
-                - ``tracer_lon_coord``
-                - ``tracer_lat_coord``
-                - ``depth_coord``
-                - ``u_var_name``
-                - ``v_var_name``
-                - ``tracer_var_names`` (a nested dict with keys ``"salt"`` and ``"temp"``)
-    """
-
-    if arakawa_grid is None:
-        # If no arakawa_grid is provided, assume the mapping is already in the correct format
-        print(
-            "No arakawa_grid provided, assuming the variable mapping for your data product is already in correct format."
-        )
-        validate_var_mapping(var_mapping, is_xhyh=False)
-        arakawa_grid = identify_arakawa_grid(var_mapping)
-        print("Arakawa {} grid detected in variable mapping".format(arakawa_grid))
-        return var_mapping
-    else:
-        if arakawa_grid not in ("A", "B", "C"):
-            raise ValueError("arakawa_grid must be one of: 'A', 'B', or 'C'")
-
-        # Validate basic var mapping structure
-        validate_var_mapping(var_mapping, is_xhyh=True)
-
-        reprocessed_var_map = {
-            "tracer_x_coord": var_mapping["xh"],
-            "tracer_y_coord": var_mapping["yh"],
-            "u_var_name": var_mapping["u"],
-            "v_var_name": var_mapping["v"],
-            "eta_var_name": var_mapping["eta"],
-            "time_var_name": var_mapping["time"],
-            "depth_coord": var_mapping["zl"],
-            "tracer_var_names": var_mapping[
-                "tracers"
-            ],  # validate_var_mapping will ensure this is a nested dict with "salt" and "temp" keys
-        }
-
-        if arakawa_grid == "A":
-            print(
-                "Applying Arakawa A grid variable mapping, which is velocities and tracers on the same grid"
-            )
-            reprocessed_var_map["u_x_coord"] = reprocessed_var_map["tracer_x_coord"]
-            reprocessed_var_map["u_y_coord"] = reprocessed_var_map["tracer_y_coord"]
-            reprocessed_var_map["v_x_coord"] = reprocessed_var_map["tracer_x_coord"]
-            reprocessed_var_map["v_y_coord"] = reprocessed_var_map["tracer_y_coord"]
-
-        elif arakawa_grid == "B":
-            print(
-                "Applying Arakawa B grid variable mapping, which is velocities on xq, yq and tracers on xh, yh."
-            )
-            if var_mapping["xq"] is None or var_mapping["yq"] is None:
-                raise ValueError(
-                    "For Arakawa B grid, variable mapping must include 'xq' and 'yq' coordinate names."
-                )
-            reprocessed_var_map["u_x_coord"] = var_mapping["xq"]
-            reprocessed_var_map["u_y_coord"] = var_mapping["yq"]
-            reprocessed_var_map["v_x_coord"] = var_mapping["xq"]
-            reprocessed_var_map["v_y_coord"] = var_mapping["yq"]
-
-        elif arakawa_grid == "C":
-            print(
-                "Applying Arakawa C grid variable mapping, which is u-velocity on xq, yh; v-velocity on xh, yq; and tracers on xh, yh."
-            )
-            if var_mapping["xq"] is None or var_mapping["yq"] is None:
-                raise ValueError(
-                    "For Arakawa C grid, variable mapping must include 'xq' and 'yq' coordinate names."
-                )
-            reprocessed_var_map["u_x_coord"] = var_mapping["xq"]
-            reprocessed_var_map["u_y_coord"] = var_mapping["yh"]
-            reprocessed_var_map["v_x_coord"] = var_mapping["xh"]
-            reprocessed_var_map["v_y_coord"] = var_mapping["yq"]
-
-        # Because curvilinear grids will have different x.y versus lat/lon but this version of the var_mapping assumes they are rectilinear, we set the
-        # x/y coord to lon/lat
-        # If you did want to use curvilinear in/out data, you would not use this xh/yh version of the var mapping and instead use the reprocessed variable mapping, which is the if part of this if/else statement
-        reprocessed_var_map["u_lon_coord"] = reprocessed_var_map["u_x_coord"]
-        reprocessed_var_map["u_lat_coord"] = reprocessed_var_map["u_y_coord"]
-        reprocessed_var_map["v_lon_coord"] = reprocessed_var_map["v_x_coord"]
-        reprocessed_var_map["v_lat_coord"] = reprocessed_var_map["v_y_coord"]
-        reprocessed_var_map["tracer_lon_coord"] = reprocessed_var_map["tracer_x_coord"]
-        reprocessed_var_map["tracer_lat_coord"] = reprocessed_var_map["tracer_y_coord"]
-
-        # One last sanity check
-        validate_var_mapping(reprocessed_var_map, is_xhyh=False)
-        return reprocessed_var_map
-
-
-def validate_var_mapping(var_map: dict, is_xhyh: bool = False) -> None:
-    """
-    Validate the structure and completeness of a variable mapping dictionary.
-
-    This function checks that all expected keys and subkeys are present in the
-    dictionary returned by the Arakawa grid variable mapping function.
-
-    Args:
-        var_map (Dict[str, Any]): The dictionary to validate.
-        is_xhyh (bool): If True, expects the input dictionary to use the ``xh/xq`` regional_mom6 format
-
-    Raises:
-        ValueError: If any required keys or subkeys are missing, or if the dictionary
-                    structure does not match the expected format.
-    """
-    if not is_xhyh:
-        required_keys = {
-            "time_var_name",
-            "u_x_coord",
-            "u_y_coord",
-            "v_x_coord",
-            "v_y_coord",
-            "u_lon_coord",
-            "u_lat_coord",
-            "v_lon_coord",
-            "v_lat_coord",
-            "tracer_x_coord",
-            "tracer_y_coord",
-            "tracer_lon_coord",
-            "tracer_lat_coord",
-            "depth_coord",
-            "u_var_name",
-            "v_var_name",
-            "eta_var_name",
-            "tracer_var_names",
-        }
-
-    else:
-        required_keys = {"time", "xh", "zl", "u", "v", "tracers", "eta"}
-
-    missing = required_keys - var_map.keys()
-    if missing:
-        raise ValueError(
-            f"Missing required keys in var_map: {', '.join(sorted(missing))}"
-        )
-    if not is_xhyh:
-        tracer_map = var_map.get("tracer_var_names")
-    else:
-        tracer_map = var_map.get("tracers")
-    # Validate nested tracer variable names
-
-    if not isinstance(tracer_map, dict):
-        raise ValueError("Expected tracers to be a dictionary.")
-
-    required_tracers = {"salt", "temp"}
-    missing_tracers = required_tracers - tracer_map.keys()
-    if missing_tracers:
-        raise ValueError(
-            f"Missing required tracer variable names: {', '.join(sorted(missing_tracers))}"
-        )
-
-
-def identify_arakawa_grid(var_mapping):
-    """identify the arakawa grid from the variable mapping"""
-    if (
-        var_mapping["v_x_coord"] == var_mapping["u_x_coord"]
-        and var_mapping["u_x_coord"] == var_mapping["tracer_x_coord"]
-    ):
-        return "A"
-    elif (
-        var_mapping["v_x_coord"] == var_mapping["u_x_coord"]
-        and var_mapping["u_x_coord"] != var_mapping["tracer_x_coord"]
-    ):
-        return "B"
-    elif (
-        var_mapping["v_x_coord"] != var_mapping["u_x_coord"]
-        and var_mapping["u_x_coord"] != var_mapping["tracer_x_coord"]
-        and var_mapping["v_y_coord"] != var_mapping["tracer_y_coord"]
-    ):
-        return "C"
-    else:
-        raise ValueError(
-            "Could not determine Arakawa grid type from provided variable mapping. Something's wrong! Please specify variable mapping correctly"
-        )

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -24,8 +24,6 @@ from regional_mom6.topo import Topo
 from regional_mom6.chl import interpolate_and_fill_seawifs
 from regional_mom6.segment import Segment
 from regional_mom6.utils import (
-    ap2ep,
-    ep2ap,
     rotate,
     find_files_by_pattern,
     try_pint_convert,
@@ -47,25 +45,6 @@ __all__ = [
     "Topo",
     "VGrid",
 ]
-
-
-def _get_angle_dx(hgrid: xr.Dataset, orientation=None) -> xr.DataArray:
-    """Return the MOM6-consistent ``angle_dx`` rotation angle (degrees) for the hgrid,
-    or a boundary slice of it.
-
-    ``angle_dx`` is computed by mom6_forge (via the expanded-supergrid method) at grid
-    construction time and is always present on ``experiment.hgrid``; see
-    :meth:`~experiment.recalculate_rotation_angle` if it ever needs to be refreshed.
-
-    Parameters
-    ----------
-    hgrid : xr.Dataset
-    """
-    if orientation is not None:
-        return rgd.coords(
-            hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
-        )["angle"]
-    return hgrid["angle_dx"]
 
 
 # Maximum tolerated disagreement (in degrees) between an hgrid.nc file's stored
@@ -1019,7 +998,7 @@ class experiment:
         rotated_u, rotated_v = rotate(
             regridded_u,
             regridded_v,
-            radian_angle=np.radians(_get_angle_dx(hgrid).values),
+            radian_angle=np.radians(hgrid.angle_dx.values),
         )
 
         # Slice the velocites to the u and v grid.

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -28,125 +28,18 @@ import dask.array as da
 import numpy as np
 import netCDF4
 import logging
-from regional_mom6.utils import get_edge
 from os.path import isfile
 
 regridding_logger = logging.getLogger(__name__)
 
-
-def coords(
-    hgrid: xr.Dataset,
-    orientation: str,
-    segment_name: str,
-    coords_at_t_points=False,
-    angle_variable_name="angle_dx",
-) -> xr.Dataset:
-    """
-    Allows us to call the coords for use in the ``xesmf.Regridder`` in the :func:`~regrid_tides` function.
-    ``self.coords`` gives us the subset of the ``hgrid`` based on the orientation.
-
-    Arguments:
-        hgrid (xr.Dataset): The horizontal grid dataset.
-        orientation (str): The orientation of the boundary.
-        segment_name (str): The name of the segment.
-        coords_at_t_points (bool, optional): Whether to return the boundary t-points instead of
-            the q/u/v of a general boundary for rotation. Default: ``False``.
-
-    Returns:
-        xr.Dataset: The correct coordinate space for the orientation
-
-    Code credit:
-
-    .. code-block:: bash
-
-        Author(s): GFDL, James Simkins, Rob Cermak, and contributors
-        Year: 2022
-        Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
-        Version: N/A
-        Type: Python Functions, Source Code
-        Web Address: https://github.com/jsimkins2/nwa25
-    """
-
-    dataset_to_get_coords = None
-
-    if coords_at_t_points:
-        regridding_logger.debug("Creating coordinates of the boundary t-points")
-
-        # Calculate t-point information
-        ds = get_hgrid_arakawa_c_points(hgrid, "t")
-
-        tangle_dx = hgrid[angle_variable_name][(ds.t_points_y, ds.t_points_x)]
-        # Assign to dataset
-        dataset_to_get_coords = xr.Dataset(
-            {
-                "x": ds.tlon,
-                "y": ds.tlat,
-                angle_variable_name: (("nyp", "nxp"), tangle_dx.values),
-            },
-            coords={"nyp": ds.nyp, "nxp": ds.nxp},
-        )
-    else:
-        regridding_logger.debug("Creating coordinates of the boundary q/u/v points")
-        # Don't have to do anything because this is the actual boundary.
-        # t-points are one-index deep and require managing.
-        dataset_to_get_coords = hgrid
-
-    # Rename nxp and nyp to locations
-    if orientation == "south":
-        rcoord = xr.Dataset(
-            {
-                "lon": dataset_to_get_coords["x"].isel(nyp=0),
-                "lat": dataset_to_get_coords["y"].isel(nyp=0),
-                "angle": dataset_to_get_coords[angle_variable_name].isel(nyp=0),
-            }
-        )
-        rcoord = rcoord.rename_dims({"nxp": f"nx_{segment_name}"})
-        rcoord.attrs["perpendicular"] = "ny"
-        rcoord.attrs["parallel"] = "nx"
-        rcoord.attrs["axis_to_expand"] = (
-            2  ## Need to keep track of which axis the 'main' coordinate corresponds to when re-adding the 'secondary' axis
-        )
-    elif orientation == "north":
-        rcoord = xr.Dataset(
-            {
-                "lon": dataset_to_get_coords["x"].isel(nyp=-1),
-                "lat": dataset_to_get_coords["y"].isel(nyp=-1),
-                "angle": dataset_to_get_coords[angle_variable_name].isel(nyp=-1),
-            }
-        )
-        rcoord = rcoord.rename_dims({"nxp": f"nx_{segment_name}"})
-        rcoord.attrs["perpendicular"] = "ny"
-        rcoord.attrs["parallel"] = "nx"
-        rcoord.attrs["axis_to_expand"] = 2
-    elif orientation == "west":
-        rcoord = xr.Dataset(
-            {
-                "lon": dataset_to_get_coords["x"].isel(nxp=0),
-                "lat": dataset_to_get_coords["y"].isel(nxp=0),
-                "angle": dataset_to_get_coords[angle_variable_name].isel(nxp=0),
-            }
-        )
-        rcoord = rcoord.rename_dims({"nyp": f"ny_{segment_name}"})
-        rcoord.attrs["perpendicular"] = "nx"
-        rcoord.attrs["parallel"] = "ny"
-        rcoord.attrs["axis_to_expand"] = 3
-    elif orientation == "east":
-        rcoord = xr.Dataset(
-            {
-                "lon": dataset_to_get_coords["x"].isel(nxp=-1),
-                "lat": dataset_to_get_coords["y"].isel(nxp=-1),
-                "angle": dataset_to_get_coords[angle_variable_name].isel(nxp=-1),
-            }
-        )
-        rcoord = rcoord.rename_dims({"nyp": f"ny_{segment_name}"})
-        rcoord.attrs["perpendicular"] = "nx"
-        rcoord.attrs["parallel"] = "ny"
-        rcoord.attrs["axis_to_expand"] = 3
-
-    # Make lat and lon coordinates
-    rcoord = rcoord.assign_coords(lat=rcoord["lat"], lon=rcoord["lon"])
-
-    return rcoord
+# If the array is pint possible, ensure we have the right units for main fields (eta, u, v, temp),
+# salinity and bgc tracers are a bit more abstract and should be already in the correct units, a TODO: would be to add functionality to convert these tracers
+main_field_target_units = {
+    "eta": "m",
+    "u": "m/s",
+    "v": "m/s",
+    "temp": "degC",
+}
 
 
 def get_hgrid_arakawa_c_points(hgrid: xr.Dataset, point_type="t") -> xr.Dataset:
@@ -363,7 +256,7 @@ def generate_dz(ds: xr.Dataset, z_dim_name: str) -> xr.Dataset:
 
 
 def add_secondary_dimension(
-    ds: xr.Dataset, var: str, coords, segment_name: str, to_beginning=False
+    ds: xr.Dataset, var: str, boundary, segment_name: str, to_beginning=False
 ) -> xr.Dataset:
     """Add the perpendiciular dimension to the dataset, even if it is
     only one value since it is required.
@@ -371,7 +264,9 @@ def add_secondary_dimension(
     Parameters:
         ds (xr.Dataset): The dataset to add the perpendicular dimension to
         var (str): The variable to add the perpendicular dimension to
-        coords (xr.Dataset): The output xarray Dataset from the coords function. Contains information required to add the perpendicular dimension.
+        boundary: A ``regional_mom6.boundary.Boundary`` (or any object exposing
+            ``.perpendicular``/``.axis_to_expand``) describing the boundary's
+            dimension layout, needed to add the perpendicular dimension.
         segment_name (str): The segment name
         to_beginning (bool, optional): Whether to add the perpendicular dimension to the
             beginning or to the selected position, by default False
@@ -398,14 +293,14 @@ def add_secondary_dimension(
             # Missing vertical dim or tidal coord means we don't need to offset the perpendicular
             insert_behind_by = 1
     else:
-        insert_behind_by = coords.attrs[
-            "axis_to_expand"
-        ]  # Just magic to add dim to the beginning
+        insert_behind_by = (
+            boundary.axis_to_expand
+        )  # Just magic to add dim to the beginning
 
     regridding_logger.debug(f"Expand dimensions")
     ds[var] = ds[var].expand_dims(
-        f"{coords.attrs['perpendicular']}_{segment_name}",
-        axis=coords.attrs["axis_to_expand"] - insert_behind_by,
+        f"{boundary.perpendicular}_{segment_name}",
+        axis=boundary.axis_to_expand - insert_behind_by,
     )
     return ds
 
@@ -486,101 +381,35 @@ def generate_layer_thickness(
     return ds
 
 
-def get_boundary_mask(
-    bathy: xr.Dataset,
-    side: str,
-    minimum_depth=0,
-    x_dim_name="nx",
-    y_dim_name="ny",
-) -> np.ndarray:
-    """
-    Mask out the boundary conditions based on the bathymetry. We don't want to have boundary conditions on land.
-    Parameters
-    ----------
-    bathy : xr.Dataset
-        The bathymetry dataset
-    side : str
-        The side of the boundary, "north", "south", "east", or "west"
-    minimum_depth : float, optional
-        The minimum depth to consider land, by default 0
-    Returns
-    -------
-    np.ndarray
-        The boundary mask
-    """
-
-    # Get the boundary depth
-    depth = get_edge(bathy, side, x_name=x_dim_name, y_name=y_dim_name).depth
-    # Force loading and copying to avoid shared references or lazy arrays
-    depth = depth.load().copy()
-
-    # If ntiles in bathymetry, remove it.
-    if "ntiles" in depth.dims:
-        depth = depth.isel({"ntiles": 0})
-
-    # Mask fill values
-    land = 0.0
-    ocean = 1.0
-
-    # Create mask of all ocean
-    boundary_mask = np.full(depth.shape[0] * 2 + 1, ocean)
-
-    # Fill with MOM6 version of mask (wet, wet_u,wet_c, wet_v)
-    for i in range(len(depth)):
-        if depth[i] <= minimum_depth:
-            # The points to the left and right of this t-point are land points
-            boundary_mask[(i * 2) + 2] = land
-            boundary_mask[(i * 2) + 1] = land
-            boundary_mask[(i * 2)] = land
-
-    # Add Exceptions. The MOM6 mask (wet, not wet) does not include the neighboring q point as ocean. However, that point is used at the boundary.
-    boundary_mask_og = boundary_mask.copy()
-    for index in range(1, len(boundary_mask) - 1):
-        if boundary_mask_og[index - 1] == land and boundary_mask_og[index] == ocean:
-            boundary_mask[index - 1] = ocean
-        elif boundary_mask_og[index + 1] == land and boundary_mask_og[index] == ocean:
-            boundary_mask[index + 1] = ocean
-
-    return boundary_mask
-
-
 def mask_dataset(
     ds: xr.Dataset,
-    bathymetry: xr.Dataset,
-    orientation,
-    y_dim_name="ny",
-    x_dim_name="nx",
+    boundary,
     fill_value=-1e20,
 ) -> xr.Dataset:
     """
-    This function masks the dataset to the provided bathymetry. If bathymetry is not provided, it fills all NaNs with 0.
+    This function masks the dataset using the boundary's ocean(1)/land(0) mask
+    (``boundary.mask``, already aligned point-for-point with the boundary's
+    lon/lat). If ``boundary.mask`` is ``None``, it fills all NaNs with 0 instead.
+
     Parameters
     ----------
     ds : xr.Dataset
         The dataset to mask
-    bathymetry : xr.Dataset
-        The bathymetry dataset
-    orientation : str
-        The orientation of the boundary
+    boundary : regional_mom6.boundary.Boundary
+        The boundary supplying the ocean/land mask (``boundary.mask``) and the
+        across-boundary dimension prefix (``boundary.perpendicular``).
     fill_value : float
         The value land points should be filled with
     """
     ## Add Boundary Mask ##
-    if bathymetry is not None:
+    if boundary.mask is not None:
         regridding_logger.debug(
-            "Masking to bathymetry. If you don't want this, set bathymetry_path to None in the segment class."
+            "Masking to the boundary's ocean/land mask. If you don't want this, don't pass a topo to Boundary construction."
         )
-        mask = get_boundary_mask(
-            bathymetry,
-            orientation,
-            minimum_depth=0,
-            x_dim_name=x_dim_name,
-            y_dim_name=y_dim_name,
-        )
-
+        mask = boundary.mask.values.astype(float).copy()
         mask[np.where(mask == 0)] = np.nan  # Convert Land Points to NaNs
 
-        if orientation in ["east", "west"]:
+        if boundary.perpendicular == "nx":
             mask = mask[:, np.newaxis]
         else:
             mask = mask[np.newaxis, :]
@@ -607,12 +436,12 @@ def mask_dataset(
             ds[var].values = ds[var].fillna(fill_value)
     else:
         regridding_logger.warning(
-            "All NaNs filled b/c bathymetry wasn't provided to the function. "
-            + "Add bathymetry_path to the segment class to avoid this"
+            "All NaNs filled b/c no ocean/land mask was available. "
+            + "Pass a topo to Boundary construction to avoid this."
         )
         ds = ds.fillna(
             0
-        )  # Without bathymetry, we can't assume the nans will be allowed in Boundary Conditions
+        )  # Without a mask, we can't assume the nans will be allowed in Boundary Conditions
     return ds
 
 
@@ -646,3 +475,286 @@ def generate_encoding(
             }
 
     return encoding_dict
+
+
+def create_vt_regridders(
+    reprocessed_var_map: dict,
+    rawseg: xr.Dataset,
+    coords: xr.Dataset,
+    outfolder: str,
+    regridding_method: str,
+    id: str = "",
+) -> dict[str, xe.Regridder]:
+    """
+    Create regridders for velocity and tracer variables based on the specified Arakawa grid.
+
+    This function uses a validated variable mapping to create one or more
+    `xesmf.Regridder` objects for velocity (`u`, `v`) and tracer fields,
+    depending on the detected Arakawa grid type.
+
+    Args:
+        reprocessed_var_map: Mapping of variable and coordinate names, including nested
+            tracer variable names (e.g., {"tracers": {"salt": "salt", "temp": "temp"}}).
+        raw_seg: The source dataset containing the original variables.
+        coords: The target grid coordinates dataset.
+        outfolder: Path to the output folder where regridding weights are saved.
+        regridding_method: The interpolation method (default: "bilinear").
+        id: Optional string identifier appended to output weight filenames.
+
+    Returns:
+        dict[str, xe.Regridder]: A dictionary containing the created regridders with keys:
+            - "tracers"
+            - "u"
+            - "v"
+    """
+    regridders = {}
+    arakawa_grid = identify_arakawa_grid(reprocessed_var_map)
+    outfolder = Path(outfolder)
+    regridders["tracers"] = create_regridder(
+        rawseg[reprocessed_var_map["tracer_var_names"]["salt"]].rename(
+            {
+                reprocessed_var_map["tracer_lon_coord"]: "lon",
+                reprocessed_var_map["tracer_lat_coord"]: "lat",
+            }
+        ),
+        coords,
+        outfolder / f"weights/bilinear_tracer_weights_{id}.nc",
+        method=regridding_method,
+    )
+
+    if arakawa_grid == "B" or arakawa_grid == "C":
+        regridders["u"] = create_regridder(
+            rawseg[reprocessed_var_map["u_var_name"]].rename(
+                {
+                    reprocessed_var_map["u_lon_coord"]: "lon",
+                    reprocessed_var_map["u_lat_coord"]: "lat",
+                }
+            ),
+            coords,
+            outfolder / f"weights/bilinear_u_weights_{id}.nc",
+            method=regridding_method,
+        )
+    else:  # Arakawa A
+        regridders["u"] = regridders["tracers"]
+
+    if arakawa_grid == "C":
+        regridders["v"] = create_regridder(
+            rawseg[reprocessed_var_map["v_var_name"]].rename(
+                {
+                    reprocessed_var_map["v_lon_coord"]: "lon",
+                    reprocessed_var_map["v_lat_coord"]: "lat",
+                }
+            ),
+            coords,
+            outfolder / f"weights/bilinear_v_weights_{id}.nc",
+            method=regridding_method,
+        )
+    else:  # Arakawa A and B
+        regridders["v"] = regridders["u"]
+
+    return regridders
+
+
+def apply_arakawa_grid_mapping(var_mapping: dict, arakawa_grid: str = None) -> dict:
+    """
+    Map variable and coordinate names according to the specified Arakawa grid type.
+
+    This function checks the provided Arakawa grid type and constructs a consistent
+    mapping between standard variable keys (e.g., tracer, velocity components) and
+    their corresponding actual names. It raises an error if any required variable
+    names are missing for the specified grid type.
+
+    Args:
+        var_mappings (Dict[str, str]):
+            A dictionary mapping standardized variable/dimension names to their actual
+            names. Input names can use either the ``xh/xq`` convention with a specific arakawa grid or the exact output
+            format produced by this function without the arakawa_grid specified (which it will only then do the sanity checks).
+        arakawa_grid (str):
+            The Arakawa grid staggering type of the boundary forcing. Must be one of:
+            ``'A'``, ``'B'``, or ``'C'``.
+
+    Returns:
+        Dict[str, Any]:
+            A dictionary containing variable names mapped according to the specified
+            Arakawa grid type. The returned dictionary includes the following keys:
+                - ``u_x_coord``
+                - ``u_y_coord``
+                - ``v_x_coord``
+                - ``v_y_coord``
+                - ``tracer_x_coord``
+                - ``tracer_y_coord``
+                - ``u_lon_coord``
+                - ``u_lat_coord``
+                - ``v_lon_coord``
+                - ``v_lat_coord``
+                - ``tracer_lon_coord``
+                - ``tracer_lat_coord``
+                - ``depth_coord``
+                - ``u_var_name``
+                - ``v_var_name``
+                - ``tracer_var_names`` (a nested dict with keys ``"salt"`` and ``"temp"``)
+    """
+
+    if arakawa_grid is None:
+        # If no arakawa_grid is provided, assume the mapping is already in the correct format
+        print(
+            "No arakawa_grid provided, assuming the variable mapping for your data product is already in correct format."
+        )
+        validate_var_mapping(var_mapping, is_xhyh=False)
+        arakawa_grid = identify_arakawa_grid(var_mapping)
+        print("Arakawa {} grid detected in variable mapping".format(arakawa_grid))
+        return var_mapping
+    else:
+        if arakawa_grid not in ("A", "B", "C"):
+            raise ValueError("arakawa_grid must be one of: 'A', 'B', or 'C'")
+
+        # Validate basic var mapping structure
+        validate_var_mapping(var_mapping, is_xhyh=True)
+
+        reprocessed_var_map = {
+            "tracer_x_coord": var_mapping["xh"],
+            "tracer_y_coord": var_mapping["yh"],
+            "u_var_name": var_mapping["u"],
+            "v_var_name": var_mapping["v"],
+            "eta_var_name": var_mapping["eta"],
+            "time_var_name": var_mapping["time"],
+            "depth_coord": var_mapping["zl"],
+            "tracer_var_names": var_mapping[
+                "tracers"
+            ],  # validate_var_mapping will ensure this is a nested dict with "salt" and "temp" keys
+        }
+
+        if arakawa_grid == "A":
+            print(
+                "Applying Arakawa A grid variable mapping, which is velocities and tracers on the same grid"
+            )
+            reprocessed_var_map["u_x_coord"] = reprocessed_var_map["tracer_x_coord"]
+            reprocessed_var_map["u_y_coord"] = reprocessed_var_map["tracer_y_coord"]
+            reprocessed_var_map["v_x_coord"] = reprocessed_var_map["tracer_x_coord"]
+            reprocessed_var_map["v_y_coord"] = reprocessed_var_map["tracer_y_coord"]
+
+        elif arakawa_grid == "B":
+            print(
+                "Applying Arakawa B grid variable mapping, which is velocities on xq, yq and tracers on xh, yh."
+            )
+            if var_mapping["xq"] is None or var_mapping["yq"] is None:
+                raise ValueError(
+                    "For Arakawa B grid, variable mapping must include 'xq' and 'yq' coordinate names."
+                )
+            reprocessed_var_map["u_x_coord"] = var_mapping["xq"]
+            reprocessed_var_map["u_y_coord"] = var_mapping["yq"]
+            reprocessed_var_map["v_x_coord"] = var_mapping["xq"]
+            reprocessed_var_map["v_y_coord"] = var_mapping["yq"]
+
+        elif arakawa_grid == "C":
+            print(
+                "Applying Arakawa C grid variable mapping, which is u-velocity on xq, yh; v-velocity on xh, yq; and tracers on xh, yh."
+            )
+            if var_mapping["xq"] is None or var_mapping["yq"] is None:
+                raise ValueError(
+                    "For Arakawa C grid, variable mapping must include 'xq' and 'yq' coordinate names."
+                )
+            reprocessed_var_map["u_x_coord"] = var_mapping["xq"]
+            reprocessed_var_map["u_y_coord"] = var_mapping["yh"]
+            reprocessed_var_map["v_x_coord"] = var_mapping["xh"]
+            reprocessed_var_map["v_y_coord"] = var_mapping["yq"]
+
+        # Because curvilinear grids will have different x.y versus lat/lon but this version of the var_mapping assumes they are rectilinear, we set the
+        # x/y coord to lon/lat
+        # If you did want to use curvilinear in/out data, you would not use this xh/yh version of the var mapping and instead use the reprocessed variable mapping, which is the if part of this if/else statement
+        reprocessed_var_map["u_lon_coord"] = reprocessed_var_map["u_x_coord"]
+        reprocessed_var_map["u_lat_coord"] = reprocessed_var_map["u_y_coord"]
+        reprocessed_var_map["v_lon_coord"] = reprocessed_var_map["v_x_coord"]
+        reprocessed_var_map["v_lat_coord"] = reprocessed_var_map["v_y_coord"]
+        reprocessed_var_map["tracer_lon_coord"] = reprocessed_var_map["tracer_x_coord"]
+        reprocessed_var_map["tracer_lat_coord"] = reprocessed_var_map["tracer_y_coord"]
+
+        # One last sanity check
+        validate_var_mapping(reprocessed_var_map, is_xhyh=False)
+        return reprocessed_var_map
+
+
+def validate_var_mapping(var_map: dict, is_xhyh: bool = False) -> None:
+    """
+    Validate the structure and completeness of a variable mapping dictionary.
+
+    This function checks that all expected keys and subkeys are present in the
+    dictionary returned by the Arakawa grid variable mapping function.
+
+    Args:
+        var_map (Dict[str, Any]): The dictionary to validate.
+        is_xhyh (bool): If True, expects the input dictionary to use the ``xh/xq`` regional_mom6 format
+
+    Raises:
+        ValueError: If any required keys or subkeys are missing, or if the dictionary
+                    structure does not match the expected format.
+    """
+    if not is_xhyh:
+        required_keys = {
+            "time_var_name",
+            "u_x_coord",
+            "u_y_coord",
+            "v_x_coord",
+            "v_y_coord",
+            "u_lon_coord",
+            "u_lat_coord",
+            "v_lon_coord",
+            "v_lat_coord",
+            "tracer_x_coord",
+            "tracer_y_coord",
+            "tracer_lon_coord",
+            "tracer_lat_coord",
+            "depth_coord",
+            "u_var_name",
+            "v_var_name",
+            "eta_var_name",
+            "tracer_var_names",
+        }
+
+    else:
+        required_keys = {"time", "xh", "zl", "u", "v", "tracers", "eta"}
+
+    missing = required_keys - var_map.keys()
+    if missing:
+        raise ValueError(
+            f"Missing required keys in var_map: {', '.join(sorted(missing))}"
+        )
+    if not is_xhyh:
+        tracer_map = var_map.get("tracer_var_names")
+    else:
+        tracer_map = var_map.get("tracers")
+    # Validate nested tracer variable names
+
+    if not isinstance(tracer_map, dict):
+        raise ValueError("Expected tracers to be a dictionary.")
+
+    required_tracers = {"salt", "temp"}
+    missing_tracers = required_tracers - tracer_map.keys()
+    if missing_tracers:
+        raise ValueError(
+            f"Missing required tracer variable names: {', '.join(sorted(missing_tracers))}"
+        )
+
+
+def identify_arakawa_grid(var_mapping):
+    """identify the arakawa grid from the variable mapping"""
+    if (
+        var_mapping["v_x_coord"] == var_mapping["u_x_coord"]
+        and var_mapping["u_x_coord"] == var_mapping["tracer_x_coord"]
+    ):
+        return "A"
+    elif (
+        var_mapping["v_x_coord"] == var_mapping["u_x_coord"]
+        and var_mapping["u_x_coord"] != var_mapping["tracer_x_coord"]
+    ):
+        return "B"
+    elif (
+        var_mapping["v_x_coord"] != var_mapping["u_x_coord"]
+        and var_mapping["u_x_coord"] != var_mapping["tracer_x_coord"]
+        and var_mapping["v_y_coord"] != var_mapping["tracer_y_coord"]
+    ):
+        return "C"
+    else:
+        raise ValueError(
+            "Could not determine Arakawa grid type from provided variable mapping. Something's wrong! Please specify variable mapping correctly"
+        )

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -256,7 +256,7 @@ def generate_dz(ds: xr.Dataset, z_dim_name: str) -> xr.Dataset:
 
 
 def add_secondary_dimension(
-    ds: xr.Dataset, var: str, boundary, segment_name: str, to_beginning=False
+    ds: xr.Dataset, var: str, segment, segment_name: str, to_beginning=False
 ) -> xr.Dataset:
     """Add the perpendiciular dimension to the dataset, even if it is
     only one value since it is required.
@@ -264,8 +264,8 @@ def add_secondary_dimension(
     Parameters:
         ds (xr.Dataset): The dataset to add the perpendicular dimension to
         var (str): The variable to add the perpendicular dimension to
-        boundary: A ``regional_mom6.boundary.Boundary`` (or any object exposing
-            ``.perpendicular``/``.axis_to_expand``) describing the boundary's
+        segment: A ``regional_mom6.segment.Segment`` (or any object exposing
+            ``.perpendicular``/``.axis_to_expand``) describing the segment's
             dimension layout, needed to add the perpendicular dimension.
         segment_name (str): The segment name
         to_beginning (bool, optional): Whether to add the perpendicular dimension to the
@@ -294,13 +294,13 @@ def add_secondary_dimension(
             insert_behind_by = 1
     else:
         insert_behind_by = (
-            boundary.axis_to_expand
+            segment.axis_to_expand
         )  # Just magic to add dim to the beginning
 
     regridding_logger.debug(f"Expand dimensions")
     ds[var] = ds[var].expand_dims(
-        f"{boundary.perpendicular}_{segment_name}",
-        axis=boundary.axis_to_expand - insert_behind_by,
+        f"{segment.perpendicular}_{segment_name}",
+        axis=segment.axis_to_expand - insert_behind_by,
     )
     return ds
 
@@ -383,39 +383,39 @@ def generate_layer_thickness(
 
 def mask_dataset(
     ds: xr.Dataset,
-    boundary,
+    segment,
     fill_value=-1e20,
 ) -> xr.Dataset:
     """
-    This function masks the dataset using the boundary's ocean(1)/land(0) mask
-    (``boundary.mask``, already aligned point-for-point with the boundary's
-    lon/lat). If ``boundary.mask`` is ``None``, it fills all NaNs with 0 instead.
+    This function masks the dataset using the segment's ocean(1)/land(0) mask
+    (``segment.mask``, already aligned point-for-point with the segment's
+    lon/lat). If ``segment.mask`` is ``None``, it fills all NaNs with 0 instead.
 
     Parameters
     ----------
     ds : xr.Dataset
         The dataset to mask
-    boundary : regional_mom6.boundary.Boundary
-        The boundary supplying the ocean/land mask (``boundary.mask``) and the
-        across-boundary dimension prefix (``boundary.perpendicular``).
+    segment : regional_mom6.segment.Segment
+        The segment supplying the ocean/land mask (``segment.mask``) and the
+        across-segment dimension prefix (``segment.perpendicular``).
     fill_value : float
         The value land points should be filled with
     """
-    ## Add Boundary Mask ##
-    if boundary.mask is not None:
+    ## Add Segment Mask ##
+    if segment.mask is not None:
         regridding_logger.debug(
-            "Masking to the boundary's ocean/land mask. If you don't want this, don't pass a topo to Boundary construction."
+            "Masking to the segment's ocean/land mask. If you don't want this, don't pass a topo to Segment construction."
         )
-        mask = boundary.mask.values.astype(float).copy()
+        mask = segment.mask.values.astype(float).copy()
         mask[np.where(mask == 0)] = np.nan  # Convert Land Points to NaNs
 
-        if boundary.perpendicular == "nx":
+        if segment.perpendicular == "nx":
             mask = mask[:, np.newaxis]
         else:
             mask = mask[np.newaxis, :]
 
         for var in ds.data_vars.keys():
-            # Drop to just the Boundary Dim
+            # Drop to just the Segment Dim
             da = ds[var].isel({dim: 0 for dim in list(ds[var].dims)[:-2]}).squeeze()
 
             nans_in_data = np.where(np.isnan(da))
@@ -437,7 +437,7 @@ def mask_dataset(
     else:
         regridding_logger.warning(
             "All NaNs filled b/c no ocean/land mask was available. "
-            + "Pass a topo to Boundary construction to avoid this."
+            + "Pass a topo to Segment construction to avoid this."
         )
         ds = ds.fillna(
             0

--- a/regional_mom6/segment.py
+++ b/regional_mom6/segment.py
@@ -404,9 +404,7 @@ class Segment:
         cls, hgrid: xr.Dataset, spec: dict, segment_name: str, topo=None
     ) -> "Segment":
         """Rebuild a ``Segment`` from a dict produced by :meth:`to_spec`."""
-        index_range = (
-            slice(*spec["index_range"]) if spec.get("index_range") else None
-        )
+        index_range = slice(*spec["index_range"]) if spec.get("index_range") else None
         return cls.from_hgrid(
             hgrid,
             axis=spec["axis"],

--- a/regional_mom6/segment.py
+++ b/regional_mom6/segment.py
@@ -17,6 +17,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from mom6_forge.grid import Grid
+
 from regional_mom6 import regridding as rgd
 from regional_mom6.utils import ap2ep, ep2ap, rotate, try_pint_convert
 from regional_mom6.validate import validate_obc_file
@@ -69,6 +71,9 @@ class Segment:
         axis_to_expand,
         mask=None,
         grid_index=None,
+        axis=None,
+        index=None,
+        index_range=None,
     ):
         self.lon = lon
         self.lat = lat
@@ -79,6 +84,9 @@ class Segment:
         self.axis_to_expand = axis_to_expand
         self.mask = mask
         self._grid_index = grid_index
+        self._axis = axis
+        self._index = index
+        self._index_range = index_range
         self._regridders = None
         self._tidal_regridders = None
 
@@ -169,6 +177,9 @@ class Segment:
             axis_to_expand=axis_to_expand,
             mask=mask,
             grid_index=grid_index,
+            axis=axis,
+            index=index,
+            index_range=index_range,
         )
 
     @staticmethod
@@ -291,6 +302,119 @@ class Segment:
             index_range=index_range,
             topo=topo,
             mom6_index_reverse=_CARDINAL_REVERSE[orientation],
+        )
+
+    @classmethod
+    def from_lonlat(
+        cls,
+        hgrid: xr.Dataset,
+        *,
+        axis: str,
+        segment_name: str,
+        fixed_lat: float = None,
+        fixed_lon: float = None,
+        lon_range=None,
+        lat_range=None,
+        topo=None,
+        mom6_index_reverse: bool = False,
+    ) -> "Segment":
+        """
+        Build a segment from physical coordinates instead of raw supergrid
+        indices, resolving the nearest T-cell on ``hgrid`` itself (via a
+        ``mom6_forge.Grid`` built from it) and delegating to
+        :meth:`from_hgrid`.
+
+        For ``axis="nyp"`` (a line running east-west): pass ``fixed_lat`` and
+        ``lon_range=(lon0, lon1)``. For ``axis="nxp"`` (a line running
+        north-south): pass ``fixed_lon`` and ``lat_range=(lat0, lat1)``.
+
+        This is a nearest-T-cell approximation, exact on a uniform
+        rectilinear grid (where ``j`` depends only on latitude and ``i``
+        only on longitude); on a curvilinear/rotated grid it still resolves
+        to a single straight index-aligned line, but that line may drift
+        from the requested fixed coordinate away from the two endpoints.
+
+        Arguments:
+            hgrid (xarray.Dataset): The horizontal supergrid dataset.
+            axis (str): ``"nyp"`` or ``"nxp"``, as in :meth:`from_hgrid`.
+            segment_name (str): Name of the segment, e.g., ``'segment_001'``.
+            fixed_lat (float): Required for ``axis="nyp"``.
+            fixed_lon (float): Required for ``axis="nxp"``.
+            lon_range (tuple[float, float]): Required for ``axis="nyp"``.
+            lat_range (tuple[float, float]): Required for ``axis="nxp"``.
+            topo (mom6_forge.topo.Topo, optional): See :meth:`from_hgrid`.
+            mom6_index_reverse (bool): See :meth:`from_hgrid`.
+        """
+        grid = Grid.from_supergrid_ds(hgrid)
+
+        if axis == "nyp":
+            if fixed_lat is None or lon_range is None:
+                raise ValueError("axis='nyp' requires fixed_lat and lon_range")
+            j0, i0 = grid.get_indices(fixed_lat, lon_range[0])
+            _, i1 = grid.get_indices(fixed_lat, lon_range[1])
+            index = 2 * j0 + 1
+            index_range = slice(2 * min(i0, i1), 2 * max(i0, i1) + 2)
+        elif axis == "nxp":
+            if fixed_lon is None or lat_range is None:
+                raise ValueError("axis='nxp' requires fixed_lon and lat_range")
+            j0, i0 = grid.get_indices(lat_range[0], fixed_lon)
+            j1, _ = grid.get_indices(lat_range[1], fixed_lon)
+            index = 2 * i0 + 1
+            index_range = slice(2 * min(j0, j1), 2 * max(j0, j1) + 2)
+        else:
+            raise ValueError("axis must be one of: 'nyp', 'nxp'")
+
+        return cls.from_hgrid(
+            hgrid,
+            axis=axis,
+            index=index,
+            segment_name=segment_name,
+            index_range=index_range,
+            topo=topo,
+            mom6_index_reverse=mom6_index_reverse,
+        )
+
+    def to_spec(self) -> dict:
+        """
+        A small, JSON-serializable dict describing how this segment was cut
+        from its ``hgrid`` -- everything needed to reconstruct an equivalent
+        ``Segment`` later via :meth:`from_spec`, without holding onto the
+        ``hgrid``/``topo`` objects themselves.
+        """
+        if self._axis is None:
+            raise ValueError(
+                "to_spec() needs the axis/index bookkeeping recorded by "
+                "Segment.from_hgrid/Segment.cardinal/Segment.from_lonlat -- "
+                "this Segment was constructed directly and has nothing to "
+                "serialize."
+            )
+        return {
+            "axis": self._axis,
+            "index": self._index,
+            "index_range": (
+                [self._index_range.start, self._index_range.stop]
+                if self._index_range is not None
+                else None
+            ),
+            "mom6_index_reverse": self._grid_index["reverse"],
+        }
+
+    @classmethod
+    def from_spec(
+        cls, hgrid: xr.Dataset, spec: dict, segment_name: str, topo=None
+    ) -> "Segment":
+        """Rebuild a ``Segment`` from a dict produced by :meth:`to_spec`."""
+        index_range = (
+            slice(*spec["index_range"]) if spec.get("index_range") else None
+        )
+        return cls.from_hgrid(
+            hgrid,
+            axis=spec["axis"],
+            index=spec["index"],
+            segment_name=segment_name,
+            index_range=index_range,
+            topo=topo,
+            mom6_index_reverse=spec.get("mom6_index_reverse", False),
         )
 
     @property

--- a/regional_mom6/segment.py
+++ b/regional_mom6/segment.py
@@ -1,9 +1,10 @@
 """
-Boundary: a self-contained description of a single straight, index-aligned
-MOM6 open boundary condition (OBC) line, plus the regridding/rotation/masking/
-writing logic needed to turn raw forcing data into MOM6 OBC segment files.
+Segment: a self-contained description of a single straight, index-aligned
+MOM6 open boundary condition (OBC) segment, plus the regridding/rotation/
+masking/writing logic needed to turn raw forcing data into MOM6 OBC segment
+files.
 
-A ``Boundary`` only ever needs a small slice of a horizontal grid (and,
+A ``Segment`` only ever needs a small slice of a horizontal grid (and,
 optionally, a matching ``mom6_forge.Topo`` for masking) -- it never needs the
 whole ``experiment``/rest of the domain, so it can be built and exercised on
 its own, independent of ``experiment``.
@@ -28,23 +29,31 @@ _CARDINAL_AXES = {
     "east": ("nxp", -1),
 }
 
+# Whether the parallel (along-segment) MOM6 index counts up or down for each
+# legacy full-edge case, matching MOM6's requirement that the domain interior
+# stay on the same side all the way around the perimeter: walking south (I
+# ascending) -> east (J ascending) -> north (I descending) -> west (J
+# descending) traces the perimeter counterclockwise, keeping the interior on
+# the left throughout.
+_CARDINAL_REVERSE = {"south": False, "east": False, "north": True, "west": True}
 
-class Boundary:
+
+class Segment:
     """
-    The geometry of a single straight boundary line, plus the ability to
+    The geometry of a single straight MOM6 OBC segment, plus the ability to
     regrid raw forcing data onto it and write MOM6-ready segment files.
 
     Fields (set once at construction, never mutated):
-        lon (xarray.DataArray): 1-D longitude along the boundary.
-        lat (xarray.DataArray): 1-D latitude along the boundary, same dims as ``lon``.
+        lon (xarray.DataArray): 1-D longitude along the segment.
+        lat (xarray.DataArray): 1-D latitude along the segment, same dims as ``lon``.
         angle (xarray.DataArray): Rotation angle (degrees) at each point along the
-            boundary, same dims as ``lon``.
+            segment, same dims as ``lon``.
         segment_name (str): Name of the segment, e.g., ``'segment_001'``.
-        parallel (str): ``"nx"`` or ``"ny"`` -- the along-boundary logical dim prefix.
-        perpendicular (str): ``"ny"`` or ``"nx"`` -- the across-boundary logical dim prefix.
+        parallel (str): ``"nx"`` or ``"ny"`` -- the along-segment logical dim prefix.
+        perpendicular (str): ``"ny"`` or ``"nx"`` -- the across-segment logical dim prefix.
         axis_to_expand (int): Which axis the "main" coordinate corresponds to when
             re-adding the perpendicular axis during regridding.
-        mask (Optional[xarray.DataArray]): 1-D ocean(1)/land(0) mask along the boundary,
+        mask (Optional[xarray.DataArray]): 1-D ocean(1)/land(0) mask along the segment,
             same dims as ``lon``. ``None`` means no masking is applied.
     """
 
@@ -59,6 +68,7 @@ class Boundary:
         perpendicular,
         axis_to_expand,
         mask=None,
+        grid_index=None,
     ):
         self.lon = lon
         self.lat = lat
@@ -68,6 +78,7 @@ class Boundary:
         self.perpendicular = perpendicular
         self.axis_to_expand = axis_to_expand
         self.mask = mask
+        self._grid_index = grid_index
         self._regridders = None
         self._tidal_regridders = None
 
@@ -81,25 +92,34 @@ class Boundary:
         segment_name: str,
         index_range=None,
         topo=None,
-    ) -> "Boundary":
+        mom6_index_reverse: bool = False,
+    ) -> "Segment":
         """
-        Slice a straight boundary line out of ``hgrid``.
+        Slice a straight segment out of ``hgrid``.
 
         Arguments:
             hgrid (xarray.Dataset): The horizontal supergrid dataset.
-            axis (str): Which supergrid axis is held fixed -- ``"nyp"`` for a boundary
+            axis (str): Which supergrid axis is held fixed -- ``"nyp"`` for a segment
                 that runs east-west (varies in x), ``"nxp"`` for one that runs
                 north-south (varies in y).
             index (int): The fixed index along ``axis``. ``0`` or ``-1`` gives a full
                 outer edge (the legacy north/south/east/west cases); any other value
                 gives an interior/arbitrary line.
             segment_name (str): Name of the segment, e.g., ``'segment_001'``.
-            index_range (slice, optional): Restrict the boundary to part of the line
+            index_range (slice, optional): Restrict the segment to part of the line
                 along the other (parallel) axis instead of its full length.
                 Default ``None`` (whole line).
             topo (mom6_forge.topo.Topo, optional): A ``Topo`` instance for the same
                 grid. If given, its ``supergridmask`` is sliced the same way to build
-                the boundary's ocean/land mask. Default ``None`` (no masking).
+                the segment's ocean/land mask. Default ``None`` (no masking).
+            mom6_index_reverse (bool): Default direction used by
+                :meth:`mom6_obc_position_string` for this segment's along-segment
+                (parallel) MOM6 index -- ``False`` counts up, ``True`` counts down.
+                MOM6 requires the domain interior to stay on the same side all the
+                way around a segment, which for a line that isn't a full outer edge
+                depends on which side of the line is ocean -- something only the
+                caller knows. Default ``False`` (count up); pass ``True`` if that's
+                wrong for your segment, or override per call.
         """
         if axis not in ("nyp", "nxp"):
             raise ValueError("axis must be one of: 'nyp', 'nxp'")
@@ -111,13 +131,17 @@ class Boundary:
         else:
             warnings.warn(
                 "hgrid has no 'angle_dx' variable -- assuming zero rotation for this "
-                "boundary. If your grid is rotated, compute angle_dx yourself (e.g. "
+                "segment. If your grid is rotated, compute angle_dx yourself (e.g. "
                 "via mom6_forge's grid generation) before calling from_hgrid."
             )
             angle = xr.zeros_like(lon)
         mask = topo.supergridmask.isel({axis: index}) if topo is not None else None
 
         parallel_axis = "nxp" if axis == "nyp" else "nyp"
+        grid_index = cls._compute_grid_index(
+            hgrid, axis, index, parallel_axis, index_range, mom6_index_reverse
+        )
+
         if index_range is not None:
             lon = lon.isel({parallel_axis: index_range})
             lat = lat.isel({parallel_axis: index_range})
@@ -144,7 +168,92 @@ class Boundary:
             perpendicular=perpendicular,
             axis_to_expand=axis_to_expand,
             mask=mask,
+            grid_index=grid_index,
         )
+
+    @staticmethod
+    def _compute_grid_index(hgrid, axis, index, parallel_axis, index_range, reverse):
+        """Bookkeeping for :meth:`mom6_obc_position_string`: convert a supergrid
+        axis/index/index_range into MOM6's own (half-resolution) model-grid I/J
+        numbering, resolved once at construction time."""
+        nyp_size = hgrid.sizes["nyp"]
+        nxp_size = hgrid.sizes["nxp"]
+        NJ = (nyp_size - 1) // 2
+        NI = (nxp_size - 1) // 2
+
+        fixed_size = nyp_size if axis == "nyp" else nxp_size
+        resolved_index = index if index >= 0 else fixed_size + index
+        fixed_value = resolved_index // 2
+
+        if axis == "nyp":
+            fixed_letter, fixed_max = "J", NJ
+            parallel_letter, parallel_size = "I", NI
+        else:
+            fixed_letter, fixed_max = "I", NI
+            parallel_letter, parallel_size = "J", NJ
+
+        parallel_full_size = nxp_size if parallel_axis == "nxp" else nyp_size
+        if index_range is None:
+            p_start_super, p_stop_super = 0, parallel_full_size
+        else:
+            p_start_super = index_range.start if index_range.start is not None else 0
+            p_stop_super = (
+                index_range.stop if index_range.stop is not None else parallel_full_size
+            )
+
+        return {
+            "fixed_letter": fixed_letter,
+            "fixed_value": fixed_value,
+            "fixed_max": fixed_max,
+            "parallel_letter": parallel_letter,
+            "parallel_start": p_start_super // 2,
+            "parallel_stop": (p_stop_super - 1) // 2,
+            "parallel_size": parallel_size,
+            "reverse": reverse,
+        }
+
+    def mom6_obc_position_string(self, reverse: bool = None) -> str:
+        """
+        This segment's MOM6 ``OBC_SEGMENT_00N`` grid-index position string, e.g.
+        ``"J=45,I=5:15"``, or ``"J=0,I=0:N"`` for a full south edge (``"N"`` is
+        MOM6's own last-index sentinel, resolved by MOM6 at runtime).
+
+        MOM6 numbers I/J on its own (half-resolution) model grid, not the
+        supergrid this ``Segment`` was built from -- this converts automatically.
+
+        Arguments:
+            reverse (bool, optional): Direction of the along-segment (parallel)
+                index -- ``False`` counts up, ``True`` counts down. Default
+                ``None`` uses the segment's own default (set automatically by
+                :meth:`cardinal`; ``False`` for a segment built directly via
+                :meth:`from_hgrid` unless ``mom6_index_reverse`` was passed there).
+                MOM6 requires the domain interior to stay on the same side all the
+                way around a segment; get this wrong and the segment runs backwards.
+        """
+        if self._grid_index is None:
+            raise ValueError(
+                "mom6_obc_position_string() needs grid-index bookkeeping that's only "
+                "recorded by Segment.from_hgrid/Segment.cardinal -- this Segment "
+                "was constructed directly and has no underlying grid to derive it from."
+            )
+        info = self._grid_index
+        if reverse is None:
+            reverse = info["reverse"]
+
+        def fmt(value, vmax):
+            return "N" if value == vmax else str(value)
+
+        fixed_str = (
+            f"{info['fixed_letter']}={fmt(info['fixed_value'], info['fixed_max'])}"
+        )
+        start, stop = info["parallel_start"], info["parallel_stop"]
+        if reverse:
+            start, stop = stop, start
+        parallel_str = (
+            f"{info['parallel_letter']}={fmt(start, info['parallel_size'])}:"
+            f"{fmt(stop, info['parallel_size'])}"
+        )
+        return f"{fixed_str},{parallel_str}"
 
     @classmethod
     def cardinal(
@@ -154,7 +263,7 @@ class Boundary:
         segment_name: str,
         index_range=None,
         topo=None,
-    ) -> "Boundary":
+    ) -> "Segment":
         """
         Convenience wrapper for the 4 legacy full-edge cases.
 
@@ -163,7 +272,7 @@ class Boundary:
             orientation (str): One of ``'north'``, ``'south'``, ``'east'``, ``'west'``
                 (case-insensitive).
             segment_name (str): Name of the segment, e.g., ``'segment_001'``.
-            index_range (slice, optional): Restrict the boundary to part of the edge.
+            index_range (slice, optional): Restrict the segment to part of the edge.
                 Default ``None`` (the whole edge).
             topo (mom6_forge.topo.Topo, optional): See :meth:`from_hgrid`.
         """
@@ -171,7 +280,7 @@ class Boundary:
         if orientation not in _CARDINAL_AXES:
             raise ValueError(
                 "orientation must be one of: 'north', 'south', 'east', or 'west'. "
-                "For a boundary that isn't a full outer edge, use Boundary.from_hgrid directly."
+                "For a segment that isn't a full outer edge, use Segment.from_hgrid directly."
             )
         axis, index = _CARDINAL_AXES[orientation]
         return cls.from_hgrid(
@@ -181,11 +290,12 @@ class Boundary:
             segment_name=segment_name,
             index_range=index_range,
             topo=topo,
+            mom6_index_reverse=_CARDINAL_REVERSE[orientation],
         )
 
     @property
     def _coords_ds(self) -> xr.Dataset:
-        """The boundary's lon/lat as a small xarray.Dataset, for use as the
+        """The segment's lon/lat as a small xarray.Dataset, for use as the
         ``xesmf.Regridder`` output grid. ``lon``/``lat`` must be actual
         coordinates (not just data variables) for ``xe.Regridder``'s
         ``locstream_out`` mode to carry them through to the regridded output."""
@@ -207,18 +317,18 @@ class Boundary:
         repeat_year_forcing=False,
     ):
         """
-        Cut out and interpolate the velocities and tracers onto this boundary.
+        Cut out and interpolate the velocities and tracers onto this segment.
 
         Arguments:
-            infile (Union[str, Path]): Path to the raw, unprocessed boundary segment.
+            infile (Union[str, Path]): Path to the raw, unprocessed segment forcing file.
             varnames (Dict[str, str]): Mapping between the variable/dimension names and
                 standard naming convention of this pipeline, e.g., ``{"xh": "longitude",
                 "yh": "latitude", "salt": "salinity", ...}``. Key "tracers" points to a
-                nested dictionary of tracers to include in boundary.
+                nested dictionary of tracers to include in the segment.
             outfolder (Union[str, Path]): Path to folder where the model inputs will
                 be stored.
             startdate (str): The starting date to use in the segment calendar.
-            arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary
+            arakawa_grid (Optional[str]): Arakawa grid staggering type of the segment
                 forcing. Either ``'A'`` (default), ``'B'``, or ``'C'``.
             regridding_method (str): Regridding method to use throughout the function.
                 Default is ``'bilinear'``.
@@ -229,7 +339,7 @@ class Boundary:
             regridders (dict, optional): Pre-built regridders with keys ``"tracers"``,
                 ``"u"``, ``"v"``. If provided, regridder creation is skipped entirely --
                 useful when calling this method multiple times for different time
-                windows on the same boundary (pass ``boundary._regridders`` from a
+                windows on the same segment (pass ``segment._regridders`` from a
                 prior call). Default ``None`` -- regridders are built and cached on
                 ``self._regridders`` for reuse on the next call.
             repeat_year_forcing (Optional[bool]): When ``True`` the experiment runs
@@ -302,7 +412,7 @@ class Boundary:
         rotated_v.name = reprocessed_var_map["v_var_name"]
         segment_out = xr.merge([rotated_u, rotated_v, tracers_regridded])
 
-        ## segment out now contains our interpolated boundary.
+        ## segment_out now contains our interpolated segment.
         ## Now, we need to fix up all the metadata and save
         segment_out = segment_out.rename(
             {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
@@ -488,8 +598,8 @@ class Boundary:
         repeat_year_forcing=False,
     ):
         """
-        Regrids and interpolates the tidal data for MOM6 onto this boundary. Steps
-        include:
+        Regrids and interpolates the tidal data for MOM6 onto this segment.
+        Steps include:
 
         - Read raw tidal data (all constituents)
         - Perform minor transformations/conversions
@@ -510,7 +620,7 @@ class Boundary:
             regridders (dict, optional): Pre-built regridders with keys ``"elev"``,
                 ``"u"``, ``"v"``. If provided, regridder creation is skipped entirely
                 -- useful when calling this method multiple times on the same
-                boundary (pass ``boundary._tidal_regridders`` from a prior call).
+                segment (pass ``segment._tidal_regridders`` from a prior call).
                 Default ``None`` -- regridders are built and cached on
                 ``self._tidal_regridders`` for reuse on the next call.
             repeat_year_forcing (Optional[bool]): Unused for tides (kept for
@@ -722,7 +832,7 @@ class Boundary:
             print(
                 "A land/ocean mask has been provided to the regridding tides function. "
                 "Masking tides dataset with it may result in errors like large surface values one timestep in. "
-                "To avoid masking tides, don't pass a topo to Boundary construction for tidal-only use."
+                "To avoid masking tides, don't pass a topo to Segment construction for tidal-only use."
             )
         ds = rgd.mask_dataset(ds, self)
         ## Perform Encoding ##

--- a/regional_mom6/utils.py
+++ b/regional_mom6/utils.py
@@ -298,29 +298,4 @@ def find_files_by_pattern(paths: list, patterns: list, error_message=None) -> li
     return all_files
 
 
-def get_edge(ds, edge, x_name=None, y_name=None):
-    edge = edge.lower()
-    if edge not in {"north", "south", "east", "west"}:
-        raise ValueError("edge must be one of: 'north', 'south', 'east', 'west'")
-
-    # Infer x and y coordinate names if not given
-    if x_name is None or y_name is None:
-        for dim in ds.dims:
-            if x_name is None and dim.lower() in ("x", "lon", "longitude", "nxp"):
-                x_name = dim
-            if y_name is None and dim.lower() in ("y", "lat", "latitude", "nyp"):
-                y_name = dim
-    if x_name is None or y_name is None:
-        raise ValueError("Could not infer x/y coordinate names. Pass x_name/y_name.")
-
-    if edge == "north":
-        return ds.isel({y_name: -1})
-    if edge == "south":
-        return ds.isel({y_name: 0})
-    if edge == "east":
-        return ds.isel({x_name: -1})
-    if edge == "west":
-        return ds.isel({x_name: 0})
-
-
 utils_logger = logging.getLogger(__name__)

--- a/tests/test_arakawa_grid_mapping.py
+++ b/tests/test_arakawa_grid_mapping.py
@@ -1,5 +1,5 @@
 import pytest
-from regional_mom6.regional_mom6 import (
+from regional_mom6.regridding import (
     apply_arakawa_grid_mapping,
     identify_arakawa_grid,
 )

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from regional_mom6 import experiment
+from regional_mom6.boundary import Boundary
 import xarray as xr
 import xesmf as xe
 import dask
@@ -492,3 +493,41 @@ def test_reformat_bgc_tracers_into_files(tmp_path):
         assert (
             f"temp_segment_{seg}" not in result
         ), "physical tracer should not be in BGC file"
+
+
+def test_get_boundary_reuses_cached_boundary(tmp_path, monkeypatch):
+    """_get_boundary should build a Boundary once per orientation and reuse the
+    same object on subsequent calls -- this is what lets setup_ocean_state_boundaries
+    and setup_boundary_tides share one Boundary per orientation instead of each
+    re-deriving it from the grid."""
+    expt = experiment.create_empty(
+        expt_name="cache_test",
+        mom_input_dir=tmp_path,
+        mom_run_dir=tmp_path,
+    )
+    expt.longitude_extent = (-5, 5)
+    expt.latitude_extent = (0, 10)
+    expt.hgrid_type = "even_spacing"
+    expt.resolution = 0.1
+    expt._make_hgrid()
+
+    call_count = {"n": 0}
+    real_cardinal = Boundary.cardinal.__func__
+
+    def counting_cardinal(cls, *args, **kwargs):
+        call_count["n"] += 1
+        return real_cardinal(cls, *args, **kwargs)
+
+    monkeypatch.setattr(Boundary, "cardinal", classmethod(counting_cardinal))
+
+    boundary_first = expt._get_boundary("east")
+    boundary_second = expt._get_boundary("east")
+
+    assert call_count["n"] == 1, "Boundary.cardinal should only be called once"
+    assert boundary_first is boundary_second
+    assert expt.segments["east"] is boundary_first
+
+    # A different orientation still builds its own Boundary
+    boundary_north = expt._get_boundary("north")
+    assert call_count["n"] == 2
+    assert boundary_north is not boundary_first

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -7,6 +7,8 @@ import pytest
 from regional_mom6 import experiment
 from regional_mom6 import MOM_parameter_tools as mpt
 from regional_mom6.segment import Segment
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
 import xarray as xr
 import xesmf as xe
 import dask
@@ -596,10 +598,10 @@ def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, 
 
 
 def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
-    """_get_segment should build a Segment once per orientation and reuse the
-    same object on subsequent calls -- this is what lets setup_ocean_state_boundaries
-    and setup_boundary_tides share one Segment per orientation instead of each
-    re-deriving it from the grid."""
+    """_get_segment should build a Segment once per boundary (keyed by its position
+    in expt.boundaries) and reuse the same object on subsequent calls -- this is
+    what lets setup_ocean_state_boundaries and setup_boundary_tides share one
+    Segment per boundary instead of each re-deriving it from the grid."""
     expt = experiment.create_empty(
         expt_name="cache_test",
         mom_input_dir=tmp_path,
@@ -610,6 +612,7 @@ def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
     expt.hgrid_type = "even_spacing"
     expt.resolution = 0.1
     expt._make_hgrid()
+    # create_empty's default boundaries: ["south", "north", "west", "east"]
 
     call_count = {"n": 0}
     real_cardinal = Segment.cardinal.__func__
@@ -625,9 +628,9 @@ def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
 
     assert call_count["n"] == 1, "Segment.cardinal should only be called once"
     assert segment_first is segment_second
-    assert expt.segments["east"] is segment_first
+    assert expt.segments[expt._segment_number("east")] is segment_first
 
-    # A different orientation still builds its own Segment
+    # A different boundary still builds its own Segment
     segment_north = expt._get_segment("north")
     assert call_count["n"] == 2
     assert segment_north is not segment_first
@@ -679,9 +682,109 @@ def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
         "east": '"I=N,J=0:N',
         "west": '"I=0,J=N:0',
     }
-    for seg in expt.boundaries:
-        ind_seg = expt.find_MOM6_rectangular_orientation(seg)
-        value = MOM_override_dict[f"OBC_SEGMENT_00{ind_seg}"]["value"]
+    for ind_seg, seg in enumerate(expt.boundaries, start=1):
+        value = MOM_override_dict[f"OBC_SEGMENT_{ind_seg:03d}"]["value"]
         assert value.startswith(
             expected_prefix[seg]
         ), f"{seg} position string {value!r} does not match legacy convention"
+
+
+def test_setup_generic_interior_segment_numbered_by_list_position(tmp_path):
+    """boundaries mixing cardinal strings and an interior Segment should be
+    numbered purely by list position (not by orientation), and the interior
+    segment's OBC_SEGMENT position string should come straight from its own
+    mom6_obc_position_string()."""
+    expt = experiment.create_empty(
+        expt_name="interior_numbering_test",
+        mom_input_dir=tmp_path / "inputdir",
+        mom_run_dir=tmp_path / "rundir",
+    )
+    expt.mom_input_dir.mkdir()
+    expt.mom_run_dir.mkdir()
+    expt.longitude_extent = (-5, 5)
+    expt.latitude_extent = (0, 10)
+    expt.date_range = ["2000-01-01 00:00:00", "2000-01-02 00:00:00"]
+    expt.hgrid_type = "even_spacing"
+    expt.resolution = 0.5
+    expt.number_vertical_layers = 5
+    expt.layer_thickness_ratio = 1
+    expt.depth = 1000
+    expt.minimum_depth = 4
+    expt.tidal_constituents = []
+    expt._make_hgrid()
+    expt._make_vgrid()
+
+    # An interior line (index=20 is neither 0 nor -1 on a 41-point nyp axis) --
+    # not adjacent to any bathymetry, so orientation validation is a no-op here.
+    interior_segment = Segment.from_hgrid(
+        expt.hgrid, axis="nyp", index=20, segment_name="my_interior_line"
+    )
+    expt.boundaries = ["south", "east", interior_segment]
+
+    module_path = Path(importlib.resources.files("regional_mom6"))
+    demos_dir = (
+        module_path / "demos"
+        if (module_path / "demos").exists()
+        else module_path.parent / "demos"
+    )
+    shutil.copytree(
+        demos_dir / "premade_run_directories" / "common_files",
+        expt.mom_run_dir,
+        dirs_exist_ok=True,
+    )
+
+    expt.setup_generic(mask_land_cpus=False)
+
+    MOM_override_dict = mpt.read_MOM_file_as_dict("MOM_override", expt.mom_run_dir)
+    assert int(MOM_override_dict["OBC_NUMBER_OF_SEGMENTS"]["value"]) == 3
+
+    # 3rd in the list -> OBC_SEGMENT_003, regardless of it being an interior line.
+    expected = '"' + interior_segment.mom6_obc_position_string()
+    value = MOM_override_dict["OBC_SEGMENT_003"]["value"]
+    assert value.startswith(expected)
+
+
+def test_setup_generic_raises_on_wrong_interior_orientation(tmp_path):
+    """setup_generic should reject an interior Segment whose mom6_index_reverse
+    contradicts the bathymetry: land clearly on one side of the line means only
+    one orientation is valid."""
+    grid = Grid(
+        resolution=1,
+        xstart=0,
+        lenx=10,
+        ystart=0,
+        leny=10,
+        name="orientation_test",
+        type="rectilinear_cartesian",
+    )
+    topo = Topo(grid, min_depth=5.0, git=False)
+    topo.set_flat(100.0)
+    depth = topo.depth.values.copy()
+    depth[5:10, :] = 0.0  # northern half (T-rows 5-9) is land
+    topo.depth = depth
+
+    expt = experiment.create_empty(
+        expt_name="orientation_test",
+        mom_input_dir=tmp_path / "inputdir",
+        mom_run_dir=tmp_path / "rundir",
+    )
+    expt.mom_input_dir.mkdir()
+    expt.mom_run_dir.mkdir()
+    expt.tidal_constituents = []
+    expt.m6f_hgrid = grid
+    expt.m6f_bathymetry = topo
+
+    # Line at J=5, the land/ocean boundary: south (low) side is ocean, north
+    # (high) side is land -> interior is south -> mom6_index_reverse should be
+    # True. Deliberately built with False.
+    bad_segment = Segment.from_hgrid(
+        expt.hgrid,
+        axis="nyp",
+        index=10,
+        segment_name="bad_interior",
+        mom6_index_reverse=False,
+    )
+    expt.boundaries = ["south", bad_segment]
+
+    with pytest.raises(ValueError, match="wrong along-segment direction"):
+        expt.setup_generic(mask_land_cpus=False)

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -1,7 +1,12 @@
+import importlib
+import shutil
+from pathlib import Path
+
 import numpy as np
 import pytest
 from regional_mom6 import experiment
-from regional_mom6.boundary import Boundary
+from regional_mom6 import MOM_parameter_tools as mpt
+from regional_mom6.segment import Segment
 import xarray as xr
 import xesmf as xe
 import dask
@@ -495,10 +500,10 @@ def test_reformat_bgc_tracers_into_files(tmp_path):
         ), "physical tracer should not be in BGC file"
 
 
-def test_get_boundary_reuses_cached_boundary(tmp_path, monkeypatch):
-    """_get_boundary should build a Boundary once per orientation and reuse the
+def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
+    """_get_segment should build a Segment once per orientation and reuse the
     same object on subsequent calls -- this is what lets setup_ocean_state_boundaries
-    and setup_boundary_tides share one Boundary per orientation instead of each
+    and setup_boundary_tides share one Segment per orientation instead of each
     re-deriving it from the grid."""
     expt = experiment.create_empty(
         expt_name="cache_test",
@@ -512,22 +517,76 @@ def test_get_boundary_reuses_cached_boundary(tmp_path, monkeypatch):
     expt._make_hgrid()
 
     call_count = {"n": 0}
-    real_cardinal = Boundary.cardinal.__func__
+    real_cardinal = Segment.cardinal.__func__
 
     def counting_cardinal(cls, *args, **kwargs):
         call_count["n"] += 1
         return real_cardinal(cls, *args, **kwargs)
 
-    monkeypatch.setattr(Boundary, "cardinal", classmethod(counting_cardinal))
+    monkeypatch.setattr(Segment, "cardinal", classmethod(counting_cardinal))
 
-    boundary_first = expt._get_boundary("east")
-    boundary_second = expt._get_boundary("east")
+    segment_first = expt._get_segment("east")
+    segment_second = expt._get_segment("east")
 
-    assert call_count["n"] == 1, "Boundary.cardinal should only be called once"
-    assert boundary_first is boundary_second
-    assert expt.segments["east"] is boundary_first
+    assert call_count["n"] == 1, "Segment.cardinal should only be called once"
+    assert segment_first is segment_second
+    assert expt.segments["east"] is segment_first
 
-    # A different orientation still builds its own Boundary
-    boundary_north = expt._get_boundary("north")
+    # A different orientation still builds its own Segment
+    segment_north = expt._get_segment("north")
     assert call_count["n"] == 2
-    assert boundary_north is not boundary_first
+    assert segment_north is not segment_first
+
+
+def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
+    """setup_generic's OBC_SEGMENT_00N position strings should come from
+    Segment.mom6_obc_position_string, matching the values the old hardcoded
+    rect_MOM6_index_dir produced for the 4 cardinal boundaries."""
+    expt = experiment.create_empty(
+        expt_name="obc_test",
+        mom_input_dir=tmp_path / "inputdir",
+        mom_run_dir=tmp_path / "rundir",
+    )
+    expt.mom_input_dir.mkdir()
+    expt.mom_run_dir.mkdir()
+    expt.longitude_extent = (-5, 5)
+    expt.latitude_extent = (0, 10)
+    expt.date_range = ["2000-01-01 00:00:00", "2000-01-02 00:00:00"]
+    expt.hgrid_type = "even_spacing"
+    expt.resolution = 0.5
+    expt.number_vertical_layers = 5
+    expt.layer_thickness_ratio = 1
+    expt.depth = 1000
+    expt.minimum_depth = 4
+    expt.tidal_constituents = []
+    expt.boundaries = ["south", "north", "east", "west"]
+    expt._make_hgrid()
+    expt._make_vgrid()
+
+    module_path = Path(importlib.resources.files("regional_mom6"))
+    demos_dir = (
+        module_path / "demos"
+        if (module_path / "demos").exists()
+        else module_path.parent / "demos"
+    )
+    shutil.copytree(
+        demos_dir / "premade_run_directories" / "common_files",
+        expt.mom_run_dir,
+        dirs_exist_ok=True,
+    )
+
+    expt.setup_generic(mask_land_cpus=False)
+
+    MOM_override_dict = mpt.read_MOM_file_as_dict("MOM_override", expt.mom_run_dir)
+    expected_prefix = {
+        "south": '"J=0,I=0:N',
+        "north": '"J=N,I=N:0',
+        "east": '"I=N,J=0:N',
+        "west": '"I=0,J=N:0',
+    }
+    for seg in expt.boundaries:
+        ind_seg = expt.find_MOM6_rectangular_orientation(seg)
+        value = MOM_override_dict[f"OBC_SEGMENT_00{ind_seg}"]["value"]
+        assert value.startswith(
+            expected_prefix[seg]
+        ), f"{seg} position string {value!r} does not match legacy convention"

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -1,22 +1,24 @@
 import regional_mom6 as rmom6
 import regional_mom6.regridding as rgd
 import pytest
+import warnings
 import xarray as xr
 import numpy as np
 import pandas as pd
-from regional_mom6.regional_mom6 import segment
+from regional_mom6.boundary import Boundary
 import shutil
 from mom6_forge.grid import *
+from mom6_forge.topo import Topo
 
 
-# Not testing get_arakawa_c_points, coords, & create_regridder
+# Not testing get_arakawa_c_points, & create_regridder
 def test_smoke_untested_funcs(get_curvilinear_hgrid, generate_silly_vt_dataset):
     hgrid = get_curvilinear_hgrid
     ds = generate_silly_vt_dataset
     ds["lat"] = ds.silly_lat
     ds["lon"] = ds.silly_lat
     assert rgd.get_hgrid_arakawa_c_points(hgrid, "t")
-    assert rgd.coords(hgrid, "north", "segment_002")
+    assert Boundary.cardinal(hgrid, "north", "segment_002")
     assert rgd.create_regridder(ds, ds)
 
 
@@ -64,8 +66,8 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
     hgrid = get_curvilinear_hgrid
 
     # N/S Boundary
-    coords = rgd.coords(hgrid, "north", "segment_002")
-    ds = rgd.add_secondary_dimension(ds, "temp", coords, "segment_002")
+    boundary = Boundary.cardinal(hgrid, "north", "segment_002")
+    ds = rgd.add_secondary_dimension(ds, "temp", boundary, "segment_002")
     assert ds.time.attrs == {"units": "days"}  # Assert that attributes are retained
     assert ds["temp"].dims == (
         "silly_lat",
@@ -76,9 +78,9 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
     )
 
     # E/W Boundary
-    coords = rgd.coords(hgrid, "east", "segment_003")
+    boundary = Boundary.cardinal(hgrid, "east", "segment_003")
     ds = generate_silly_vt_dataset
-    ds = rgd.add_secondary_dimension(ds, "v", coords, "segment_003")
+    ds = rgd.add_secondary_dimension(ds, "v", boundary, "segment_003")
     assert ds["v"].dims == (
         "silly_lat",
         "silly_lon",
@@ -90,14 +92,14 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
     # Beginning
     ds = generate_silly_vt_dataset
     ds = rgd.add_secondary_dimension(
-        ds, "temp", coords, "segment_003", to_beginning=True
+        ds, "temp", boundary, "segment_003", to_beginning=True
     )
     assert ds["temp"].dims[0] == "nx_segment_003"
 
     # NZ dim E/W Boundary
     ds = generate_silly_vt_dataset
     ds = ds.rename({"silly_depth": "nz"})
-    ds = rgd.add_secondary_dimension(ds, "u", coords, "segment_003")
+    ds = rgd.add_secondary_dimension(ds, "u", boundary, "segment_003")
     assert ds["u"].dims == (
         "silly_lat",
         "silly_lon",
@@ -146,132 +148,126 @@ def test_generate_encoding(generate_silly_vt_dataset):
     assert encoding_dict["temp_segment_003_nz_"]["dtype"] == "int32"
 
 
-def test_get_boundary_mask(get_curvilinear_hgrid):
-    hgrid = get_curvilinear_hgrid
-    t_points = rgd.get_hgrid_arakawa_c_points(hgrid, "t")
-    bathy = hgrid.isel(nyp=t_points.t_points_y, nxp=t_points.t_points_x)
-    bathy["depth"] = (("t_points_y", "t_points_x"), (np.full(bathy.x.shape, 0)))
-    north_mask = rgd.get_boundary_mask(
-        bathy,
-        "north",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+def _synthetic_grid_and_topo(land_ny_indices=()):
+    """A small rectilinear synthetic grid + matching Topo, all-ocean except for
+    the given t-point row indices (along ny), which are forced to land."""
+    grid = Grid(
+        resolution=2,
+        xstart=2,
+        lenx=10,
+        ystart=2,
+        leny=10,
+        name="masktest",
+        type="rectilinear_cartesian",
     )
-    south_mask = rgd.get_boundary_mask(
-        bathy,
-        "south",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+    topo = Topo(grid, min_depth=5.0, git=False)
+    topo.set_flat(100.0)
+    if land_ny_indices:
+        depth = topo.depth.values.copy()
+        for j in land_ny_indices:
+            depth[j, :] = 0.0
+        topo.depth = depth
+    return grid, topo
+
+
+def test_boundary_mask_matches_direct_supergridmask_slice():
+    """Boundary.from_hgrid's mask should be exactly topo.supergridmask sliced the
+    same way as lon/lat/angle -- no separate resolution-conversion step needed."""
+    grid, topo = _synthetic_grid_and_topo(land_ny_indices=[0])
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+
+    boundary = Boundary.from_hgrid(
+        hgrid, axis="nyp", index=-1, segment_name="segment_001", topo=topo
     )
-    east_mask = rgd.get_boundary_mask(
-        bathy,
-        "east",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+    expected = topo.supergridmask.isel(nyp=-1)
+    assert (boundary.mask.values == expected.values).all()
+
+
+def test_mask_dataset_no_mask_fills_zero():
+    """With no mask (topo=None equivalent), mask_dataset just fills NaNs with 0."""
+    boundary = Boundary(
+        lon=xr.DataArray([1.0, 2.0, 3.0], dims=["nx_segment_099"]),
+        lat=xr.DataArray([1.0, 1.0, 1.0], dims=["nx_segment_099"]),
+        angle=xr.DataArray([0.0, 0.0, 0.0], dims=["nx_segment_099"]),
+        segment_name="segment_099",
+        parallel="nx",
+        perpendicular="ny",
+        axis_to_expand=2,
+        mask=None,
     )
-    west_mask = rgd.get_boundary_mask(
-        bathy,
-        "west",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+    ds = xr.Dataset(
+        {"temp": (("ny_segment_099", "nx_segment_099"), np.array([[1.0, np.nan, 3.0]]))}
     )
+    ds = rgd.mask_dataset(ds, boundary)
+    assert (ds["temp"].values == np.array([[1.0, 0.0, 3.0]])).all()
 
-    # Check corner property of mask, and ensure each direction is following what we expect
-    for mask in [north_mask, south_mask, east_mask, west_mask]:
-        assert (mask == 0).all()  # Ensure all other points are land
-    assert north_mask.shape == (hgrid.x[-1].shape)  # Ensure mask is the right shape
-    assert south_mask.shape == (hgrid.x[0].shape)  # Ensure mask is the right shape
-    assert east_mask.shape == (hgrid.x[:, -1].shape)  # Ensure mask is the right shape
-    assert west_mask.shape == (hgrid.x[:, 0].shape)  # Ensure mask is the right shape
 
-    ## Now we check if the coast masking is correct (remember we make 3 cells into the coast be ocean)
-    start_ind = 6
-    end_ind = 9
-    for i in range(start_ind, end_ind + 1):
-        bathy["depth"][-1][i] = 15
-    north_mask = rgd.get_boundary_mask(
-        bathy,
-        "north",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+def test_mask_dataset_no_dilation():
+    """Ocean/land transitions should NOT be dilated by one point -- unlike the old
+    get_boundary_mask, boundary.mask (from Topo.supergridmask) is treated as ground
+    truth with no post-processing."""
+    boundary = Boundary(
+        lon=xr.DataArray([1.0, 2.0, 3.0, 4.0, 5.0], dims=["nx_segment_099"]),
+        lat=xr.DataArray([1.0] * 5, dims=["nx_segment_099"]),
+        angle=xr.DataArray([0.0] * 5, dims=["nx_segment_099"]),
+        segment_name="segment_099",
+        parallel="nx",
+        perpendicular="ny",
+        axis_to_expand=2,
+        mask=xr.DataArray(
+            [0, 1, 1, 0, 1], dims=["nx_segment_099"]
+        ),  # land,ocean,ocean,land,ocean
     )
-
-    # Ensure coasts are ocean with a 1 cell buffer, for the 1-point (remember mask is on the hgrid boundary - so (6 *2 +2) - 1 -> (9 *2 +2) + 1)
-    assert (
-        north_mask[(((start_ind * 2) + 1) - 1) : (((end_ind * 2) + 1) + 1 + 1)] == 1
-    ).all()
-    assert (north_mask[0 : (((start_ind * 2) + 1) - 1)] == 0).all()  # Left Side
-    assert (north_mask[(((end_ind * 2) + 1) + 1 + 1) :] == 0).all()  # Right Side
-
-    # On E/W
-    start_ind = 6
-    end_ind = 9
-    for i in range(start_ind, end_ind + 1):
-        bathy["depth"][:, 0][i] = 15
-    west_mask = rgd.get_boundary_mask(
-        bathy,
-        "west",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
+    ds = xr.Dataset(
+        {
+            "temp": (
+                ("ny_segment_099", "nx_segment_099"),
+                np.array([[10.0, 20.0, 30.0, 40.0, 50.0]]),
+            )
+        }
     )
-    # Ensure coasts are ocean with a 1 cell buffer, for the 1-point (remember mask is on the hgrid boundary - so (6 *2 +2) - 1 -> (9 *2 +2) + 1)
-    assert (
-        west_mask[(((start_ind * 2) + 1) - 1) : (((end_ind * 2) + 1) + 1 + 1)] == 1
-    ).all()
-    assert (west_mask[0 : (((start_ind * 2) + 1) - 1)] == 0).all()  # Left Side
-    assert (west_mask[(((end_ind * 2) + 1) + 1 + 1) :] == 0).all()  # Right Side
+    fill_value = -999.0
+    ds = rgd.mask_dataset(ds, boundary, fill_value=fill_value)
+    # Land points (index 0 and 3) are masked out; ocean points keep their values --
+    # in particular, index 2 (ocean, adjacent to land at index 3) is NOT dilated
+    # into being masked, and index 0/3 are NOT left unmasked just because a
+    # neighbor is ocean.
+    assert ds["temp"].values[0, 0] == fill_value
+    assert ds["temp"].values[0, 3] == fill_value
+    assert ds["temp"].values[0, 1] == 20.0
+    assert ds["temp"].values[0, 2] == 30.0
+    assert ds["temp"].values[0, 4] == 50.0
 
 
-def test_mask_dataset(get_curvilinear_hgrid):
-    hgrid = get_curvilinear_hgrid
-    t_points = rgd.get_hgrid_arakawa_c_points(hgrid, "t")
-    bathy = hgrid.isel(nyp=t_points.t_points_y, nxp=t_points.t_points_x)
-    bathy["depth"] = (("t_points_y", "t_points_x"), (np.full(bathy.x.shape, 0)))
-    ds = hgrid.copy(deep=True)
-    ds = ds.drop_vars(("tile", "area", "y", "x", "angle_dx", "dy", "dx"))
-    ds["temp"] = (("t_points_y", "t_points_x"), (np.full(hgrid.x.shape, 100)))
-    ds["temp"] = ds["temp"].isel(t_points_y=-1)
-    start_ind = 6
-    end_ind = 9
-    for i in range(start_ind, end_ind + 1):
-        bathy["depth"][-1][i] = 15
-
-    ds["temp"][start_ind * 2 + 2] = np.nan
-    ds["temp"] = ds["temp"].expand_dims("y", axis=0)
-    ds["temp"] = ds["temp"].expand_dims("nz_temp", axis=0)
-    ds["temp"] = ds["temp"].expand_dims("time", axis=0)
-    ds.temp.attrs = {"units": "C"}
-    fill_value = 36
-    ds = rgd.mask_dataset(
-        ds,
-        bathy,
-        "north",
-        y_dim_name="t_points_y",
-        x_dim_name="t_points_x",
-        fill_value=fill_value,
-    )
-    assert ds.temp.attrs == {"units": "C"}
-
-    assert (
-        np.isnan(ds["temp"][0, 0, 0][start_ind * 2 + 2]) == False
-    )  # Ensure missing value was filled
-    assert (
-        np.isnan(
-            ds["temp"][0, 0, 0][
-                (((start_ind * 2) + 1) - 1) : (((end_ind * 2) + 1) + 1 + 1)
-            ]
+def test_boundary_from_hgrid_missing_angle_dx_warns(get_rectilinear_hgrid):
+    hgrid = get_rectilinear_hgrid.drop_vars("angle_dx")
+    with pytest.warns(UserWarning, match="angle_dx"):
+        boundary = Boundary.from_hgrid(
+            hgrid, axis="nyp", index=-1, segment_name="segment_001"
         )
-    ).all() == False  # Ensure data is kept in ocean area
-    assert (
-        (ds["temp"][0, 0, 0][1 : (((start_ind * 2) + 1) - 1)] == fill_value)
-    ).all() == True and (
-        (ds["temp"][0, 0, 0][(((end_ind * 2) + 1) + 1 + 1) : -1] == fill_value)
-    ).all() == True  # Ensure data is not in land area
+    assert (boundary.angle.values == 0).all()
+
+
+def test_boundary_from_hgrid_arbitrary_axis_index_range(get_rectilinear_hgrid):
+    hgrid = get_rectilinear_hgrid
+    index_range = slice(2, 6)
+    boundary = Boundary.from_hgrid(
+        hgrid,
+        axis="nyp",
+        index=3,
+        segment_name="segment_001",
+        index_range=index_range,
+    )
+    expected_lon = hgrid["x"].isel(nyp=3).isel(nxp=index_range)
+    expected_lat = hgrid["y"].isel(nyp=3).isel(nxp=index_range)
+    assert np.allclose(boundary.lon.values, expected_lon.values)
+    assert np.allclose(boundary.lat.values, expected_lat.values)
+    assert boundary.lon.sizes["nx_segment_001"] == index_range.stop - index_range.start
 
 
 def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     """
-    Correctness test for segment.regrid_velocity_tracers.
+    Correctness test for Boundary.regrid_velocity_tracers.
 
     Checks:
     - Output OBC file is written
@@ -314,14 +310,10 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    seg = segment(
-        hgrid=hgrid,
-        outfolder=outfolder,
-        segment_name=seg_name,
-        orientation="east",
-        startdate="2003-01-01 00:00:00",
+    boundary = Boundary.cardinal(hgrid, "east", seg_name)
+    segment_out, _ = boundary.regrid_velocity_tracers(
+        infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
-    segment_out, _ = seg.regrid_velocity_tracers(infile, varnames, arakawa_grid="A")
 
     # Salt is spatially constant, so all ocean points must match exactly.
     salt_vals = segment_out[f"salt_{seg_name}"].values
@@ -332,15 +324,9 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     assert temp_vals[0, 0, 0, 0] == 22
     assert temp_vals[0, 0, 2, 0] == 26
 
-    seg_north = segment(
-        hgrid=hgrid,
-        outfolder=outfolder,
-        segment_name=seg_name,
-        orientation="north",
-        startdate="2003-01-01 00:00:00",
-    )
-    segment_out_north, _ = seg_north.regrid_velocity_tracers(
-        infile, varnames, arakawa_grid="A"
+    boundary_north = Boundary.cardinal(hgrid, "north", seg_name)
+    segment_out_north, _ = boundary_north.regrid_velocity_tracers(
+        infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
     temp_vals = segment_out_north[f"temp_{seg_name}"].values
     assert temp_vals[0, 0, 0, 0] == 24
@@ -355,15 +341,14 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     folder.mkdir()  # recreate the empty folder
     hgrid["x"] = hgrid.x + 1
     hgrid["y"] = hgrid.y + 1
-    seg_regrid = segment(
-        hgrid=hgrid,
-        outfolder=outfolder,
-        segment_name=seg_name,
-        orientation="west",
-        startdate="2003-01-01 00:00:00",
-    )
-    seg_regridded, _ = seg_regrid.regrid_velocity_tracers(
-        infile, varnames, arakawa_grid="A", regridding_method="bilinear"
+    boundary_regrid = Boundary.cardinal(hgrid, "west", seg_name)
+    seg_regridded, _ = boundary_regrid.regrid_velocity_tracers(
+        infile,
+        varnames,
+        outfolder,
+        "2003-01-01 00:00:00",
+        arakawa_grid="A",
+        regridding_method="bilinear",
     )
     temp_vals = seg_regridded[f"temp_{seg_name}"].values
     assert (
@@ -372,3 +357,109 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     assert (
         temp_vals[0, 0, 2, 0] == 0
     )  # The bilinear regridding would be zero here because there isn't 4 points
+
+
+def test_boundary_standalone_no_hgrid(toy_glorys_ds, tmp_path):
+    """Prove regrid_velocity_tracers needs nothing beyond a hand-built Boundary --
+    no mom6_forge.Grid, no hgrid, no Experiment involved at all."""
+    outfolder = tmp_path / "inputdir"
+    outfolder.mkdir()
+
+    infile = tmp_path / "raw.nc"
+    ds = toy_glorys_ds
+    ds.to_netcdf(infile)
+    ds.close()
+
+    varnames = {
+        "xh": "lon",
+        "yh": "lat",
+        "time": "time",
+        "eta": "eta",
+        "zl": "depth",
+        "u": "u",
+        "v": "v",
+        "tracers": {"temp": "temp", "salt": "salt"},
+    }
+
+    seg_name = "segment_099"
+    # A straight boundary line of 2 points, fully described by literal numbers --
+    # lon fixed at 3.0 (inside toy_glorys_ds's [2, 4] lon range), lat spanning it.
+    boundary = Boundary(
+        lon=xr.DataArray([3.0, 3.0], dims=[f"ny_{seg_name}"]),
+        lat=xr.DataArray([2.5, 3.5], dims=[f"ny_{seg_name}"]),
+        angle=xr.DataArray([0.0, 0.0], dims=[f"ny_{seg_name}"]),
+        segment_name=seg_name,
+        parallel="ny",
+        perpendicular="nx",
+        axis_to_expand=3,
+        mask=None,
+    )
+
+    segment_out, _ = boundary.regrid_velocity_tracers(
+        infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
+    )
+
+    assert (outfolder / f"forcing_obc_{seg_name}.nc").exists()
+    assert np.isfinite(segment_out[f"temp_{seg_name}"].values).all()
+    np.testing.assert_allclose(segment_out[f"salt_{seg_name}"].values, 35.0, rtol=1e-4)
+
+
+def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
+    """regrid_velocity_tracers should only rebuild regridders when regridders=None
+    -- passing back a previously-returned dict skips rebuilding, matching today's
+    documented manual-reuse pattern."""
+    grid = Grid(
+        resolution=2,
+        xstart=2,
+        lenx=2,
+        ystart=2,
+        leny=2,
+        name="test",
+        type="rectilinear_cartesian",
+    )
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+    outfolder = tmp_path / "inputdir"
+    outfolder.mkdir()
+
+    infile = tmp_path / "east_raw.nc"
+    ds = toy_glorys_ds
+    ds.to_netcdf(infile)
+    ds.close()
+
+    varnames = {
+        "xh": "lon",
+        "yh": "lat",
+        "time": "time",
+        "eta": "eta",
+        "zl": "depth",
+        "u": "u",
+        "v": "v",
+        "tracers": {"temp": "temp", "salt": "salt"},
+    }
+
+    boundary = Boundary.cardinal(hgrid, "east", "segment_001")
+
+    call_count = {"n": 0}
+    real_create_vt_regridders = rgd.create_vt_regridders
+
+    def counting_create_vt_regridders(*args, **kwargs):
+        call_count["n"] += 1
+        return real_create_vt_regridders(*args, **kwargs)
+
+    monkeypatch.setattr(rgd, "create_vt_regridders", counting_create_vt_regridders)
+
+    _, _ = boundary.regrid_velocity_tracers(
+        infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
+    )
+    assert call_count["n"] == 1
+    cached_regridders = boundary._regridders
+
+    _, _ = boundary.regrid_velocity_tracers(
+        infile,
+        varnames,
+        outfolder,
+        "2003-01-01 00:00:00",
+        arakawa_grid="A",
+        regridders=cached_regridders,
+    )
+    assert call_count["n"] == 1  # not rebuilt

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -248,6 +248,18 @@ def test_boundary_from_hgrid_missing_angle_dx_warns(get_rectilinear_hgrid):
     assert (boundary.angle.values == 0).all()
 
 
+def test_boundary_cardinal_invalid_orientation_raises(get_rectilinear_hgrid):
+    with pytest.raises(ValueError, match="orientation must be one of"):
+        Boundary.cardinal(get_rectilinear_hgrid, "northeast", "segment_001")
+
+
+def test_boundary_from_hgrid_invalid_axis_raises(get_rectilinear_hgrid):
+    with pytest.raises(ValueError, match="axis must be one of"):
+        Boundary.from_hgrid(
+            get_rectilinear_hgrid, axis="nx", index=0, segment_name="segment_001"
+        )
+
+
 def test_boundary_from_hgrid_arbitrary_axis_index_range(get_rectilinear_hgrid):
     hgrid = get_rectilinear_hgrid
     index_range = slice(2, 6)
@@ -463,3 +475,97 @@ def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
         regridders=cached_regridders,
     )
     assert call_count["n"] == 1  # not rebuilt
+
+
+def _synthetic_tidal_datasets(nc=2):
+    """Minimal synthetic TPXO-like elevation/velocity datasets, already in the
+    lon/lat/*Re/*Im form Boundary.regrid_tides expects -- skips the raw
+    h_*/u_*-file parsing that experiment.setup_boundary_tides normally does
+    (that parsing is covered separately by test_tides.py)."""
+    nx, ny = 6, 6
+    lon2d, lat2d = np.meshgrid(
+        np.linspace(277, 283, nx), np.linspace(6, 11, ny), indexing="ij"
+    )
+    rng = np.random.default_rng(0)
+
+    def _mk(*var_names):
+        data = {
+            "lon": (["nx", "ny"], lon2d),
+            "lat": (["nx", "ny"], lat2d),
+        }
+        for name in var_names:
+            data[name] = (["constituent", "nx", "ny"], rng.random((nc, nx, ny)))
+        return xr.Dataset(data, coords={"constituent": np.arange(nc)})
+
+    tpxo_h = _mk("hRe", "hIm")
+    tpxo_u = _mk("uRe", "uIm")
+    tpxo_v = _mk("vRe", "vIm")
+    return tpxo_v, tpxo_u, tpxo_h
+
+
+def test_regrid_tides_standalone(get_rectilinear_hgrid, tmp_path):
+    """Boundary.regrid_tides should run against a plain Boundary (no Experiment
+    involved) and write tz_*/tu_* files, mirroring the existing standalone
+    coverage of regrid_velocity_tracers."""
+    hgrid = get_rectilinear_hgrid
+    seg_name = "segment_001"
+    boundary = Boundary.cardinal(hgrid, "east", seg_name)
+
+    tpxo_v, tpxo_u, tpxo_h = _synthetic_tidal_datasets()
+    times = xr.DataArray(pd.date_range("2000-01-01", periods=1), dims=["time"])
+
+    outfolder = tmp_path / "inputdir"
+    outfolder.mkdir()
+
+    boundary.regrid_tides(
+        tpxo_v, tpxo_u, tpxo_h, times, outfolder, "2000-01-01 00:00:00"
+    )
+
+    assert (outfolder / f"tz_{seg_name}.nc").exists()
+    assert (outfolder / f"tu_{seg_name}.nc").exists()
+
+    tz = xr.open_dataset(outfolder / f"tz_{seg_name}.nc")
+    assert np.isfinite(tz[f"zamp_{seg_name}"].values).all()
+
+
+def test_regrid_tides_regridders_manual_reuse(
+    get_rectilinear_hgrid, tmp_path, monkeypatch
+):
+    """regrid_tides should only rebuild its 3 regridders (elev/u/v) when
+    regridders=None -- passing back boundary._tidal_regridders from a prior
+    call skips rebuilding, matching the documented manual-reuse pattern for
+    regrid_velocity_tracers."""
+    hgrid = get_rectilinear_hgrid
+    boundary = Boundary.cardinal(hgrid, "east", "segment_001")
+
+    tpxo_v, tpxo_u, tpxo_h = _synthetic_tidal_datasets()
+    times = xr.DataArray(pd.date_range("2000-01-01", periods=1), dims=["time"])
+
+    outfolder = tmp_path / "inputdir"
+    outfolder.mkdir()
+
+    call_count = {"n": 0}
+    real_create_regridder = rgd.create_regridder
+
+    def counting_create_regridder(*args, **kwargs):
+        call_count["n"] += 1
+        return real_create_regridder(*args, **kwargs)
+
+    monkeypatch.setattr(rgd, "create_regridder", counting_create_regridder)
+
+    boundary.regrid_tides(
+        tpxo_v, tpxo_u, tpxo_h, times, outfolder, "2000-01-01 00:00:00"
+    )
+    assert call_count["n"] == 3  # elev, u, v
+    cached_regridders = boundary._tidal_regridders
+
+    boundary.regrid_tides(
+        tpxo_v,
+        tpxo_u,
+        tpxo_h,
+        times,
+        outfolder,
+        "2000-01-01 00:00:00",
+        regridders=cached_regridders,
+    )
+    assert call_count["n"] == 3  # not rebuilt

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -5,7 +5,7 @@ import warnings
 import xarray as xr
 import numpy as np
 import pandas as pd
-from regional_mom6.boundary import Boundary
+from regional_mom6.segment import Segment
 import shutil
 from mom6_forge.grid import *
 from mom6_forge.topo import Topo
@@ -18,7 +18,7 @@ def test_smoke_untested_funcs(get_curvilinear_hgrid, generate_silly_vt_dataset):
     ds["lat"] = ds.silly_lat
     ds["lon"] = ds.silly_lat
     assert rgd.get_hgrid_arakawa_c_points(hgrid, "t")
-    assert Boundary.cardinal(hgrid, "north", "segment_002")
+    assert Segment.cardinal(hgrid, "north", "segment_002")
     assert rgd.create_regridder(ds, ds)
 
 
@@ -65,9 +65,9 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
     ds = generate_silly_vt_dataset
     hgrid = get_curvilinear_hgrid
 
-    # N/S Boundary
-    boundary = Boundary.cardinal(hgrid, "north", "segment_002")
-    ds = rgd.add_secondary_dimension(ds, "temp", boundary, "segment_002")
+    # N/S Segment
+    segment = Segment.cardinal(hgrid, "north", "segment_002")
+    ds = rgd.add_secondary_dimension(ds, "temp", segment, "segment_002")
     assert ds.time.attrs == {"units": "days"}  # Assert that attributes are retained
     assert ds["temp"].dims == (
         "silly_lat",
@@ -77,10 +77,10 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
         "time",
     )
 
-    # E/W Boundary
-    boundary = Boundary.cardinal(hgrid, "east", "segment_003")
+    # E/W Segment
+    segment = Segment.cardinal(hgrid, "east", "segment_003")
     ds = generate_silly_vt_dataset
-    ds = rgd.add_secondary_dimension(ds, "v", boundary, "segment_003")
+    ds = rgd.add_secondary_dimension(ds, "v", segment, "segment_003")
     assert ds["v"].dims == (
         "silly_lat",
         "silly_lon",
@@ -92,14 +92,14 @@ def test_add_secondary_dimension(get_curvilinear_hgrid, generate_silly_vt_datase
     # Beginning
     ds = generate_silly_vt_dataset
     ds = rgd.add_secondary_dimension(
-        ds, "temp", boundary, "segment_003", to_beginning=True
+        ds, "temp", segment, "segment_003", to_beginning=True
     )
     assert ds["temp"].dims[0] == "nx_segment_003"
 
-    # NZ dim E/W Boundary
+    # NZ dim E/W Segment
     ds = generate_silly_vt_dataset
     ds = ds.rename({"silly_depth": "nz"})
-    ds = rgd.add_secondary_dimension(ds, "u", boundary, "segment_003")
+    ds = rgd.add_secondary_dimension(ds, "u", segment, "segment_003")
     assert ds["u"].dims == (
         "silly_lat",
         "silly_lon",
@@ -170,22 +170,22 @@ def _synthetic_grid_and_topo(land_ny_indices=()):
     return grid, topo
 
 
-def test_boundary_mask_matches_direct_supergridmask_slice():
-    """Boundary.from_hgrid's mask should be exactly topo.supergridmask sliced the
+def test_segment_mask_matches_direct_supergridmask_slice():
+    """Segment.from_hgrid's mask should be exactly topo.supergridmask sliced the
     same way as lon/lat/angle -- no separate resolution-conversion step needed."""
     grid, topo = _synthetic_grid_and_topo(land_ny_indices=[0])
     hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
 
-    boundary = Boundary.from_hgrid(
+    segment = Segment.from_hgrid(
         hgrid, axis="nyp", index=-1, segment_name="segment_001", topo=topo
     )
     expected = topo.supergridmask.isel(nyp=-1)
-    assert (boundary.mask.values == expected.values).all()
+    assert (segment.mask.values == expected.values).all()
 
 
 def test_mask_dataset_no_mask_fills_zero():
     """With no mask (topo=None equivalent), mask_dataset just fills NaNs with 0."""
-    boundary = Boundary(
+    segment = Segment(
         lon=xr.DataArray([1.0, 2.0, 3.0], dims=["nx_segment_099"]),
         lat=xr.DataArray([1.0, 1.0, 1.0], dims=["nx_segment_099"]),
         angle=xr.DataArray([0.0, 0.0, 0.0], dims=["nx_segment_099"]),
@@ -198,15 +198,15 @@ def test_mask_dataset_no_mask_fills_zero():
     ds = xr.Dataset(
         {"temp": (("ny_segment_099", "nx_segment_099"), np.array([[1.0, np.nan, 3.0]]))}
     )
-    ds = rgd.mask_dataset(ds, boundary)
+    ds = rgd.mask_dataset(ds, segment)
     assert (ds["temp"].values == np.array([[1.0, 0.0, 3.0]])).all()
 
 
 def test_mask_dataset_no_dilation():
     """Ocean/land transitions should NOT be dilated by one point -- unlike the old
-    get_boundary_mask, boundary.mask (from Topo.supergridmask) is treated as ground
+    get_boundary_mask, segment.mask (from Topo.supergridmask) is treated as ground
     truth with no post-processing."""
-    boundary = Boundary(
+    segment = Segment(
         lon=xr.DataArray([1.0, 2.0, 3.0, 4.0, 5.0], dims=["nx_segment_099"]),
         lat=xr.DataArray([1.0] * 5, dims=["nx_segment_099"]),
         angle=xr.DataArray([0.0] * 5, dims=["nx_segment_099"]),
@@ -227,7 +227,7 @@ def test_mask_dataset_no_dilation():
         }
     )
     fill_value = -999.0
-    ds = rgd.mask_dataset(ds, boundary, fill_value=fill_value)
+    ds = rgd.mask_dataset(ds, segment, fill_value=fill_value)
     # Land points (index 0 and 3) are masked out; ocean points keep their values --
     # in particular, index 2 (ocean, adjacent to land at index 3) is NOT dilated
     # into being masked, and index 0/3 are NOT left unmasked just because a
@@ -239,31 +239,31 @@ def test_mask_dataset_no_dilation():
     assert ds["temp"].values[0, 4] == 50.0
 
 
-def test_boundary_from_hgrid_missing_angle_dx_warns(get_rectilinear_hgrid):
+def test_segment_from_hgrid_missing_angle_dx_warns(get_rectilinear_hgrid):
     hgrid = get_rectilinear_hgrid.drop_vars("angle_dx")
     with pytest.warns(UserWarning, match="angle_dx"):
-        boundary = Boundary.from_hgrid(
+        segment = Segment.from_hgrid(
             hgrid, axis="nyp", index=-1, segment_name="segment_001"
         )
-    assert (boundary.angle.values == 0).all()
+    assert (segment.angle.values == 0).all()
 
 
-def test_boundary_cardinal_invalid_orientation_raises(get_rectilinear_hgrid):
+def test_segment_cardinal_invalid_orientation_raises(get_rectilinear_hgrid):
     with pytest.raises(ValueError, match="orientation must be one of"):
-        Boundary.cardinal(get_rectilinear_hgrid, "northeast", "segment_001")
+        Segment.cardinal(get_rectilinear_hgrid, "northeast", "segment_001")
 
 
-def test_boundary_from_hgrid_invalid_axis_raises(get_rectilinear_hgrid):
+def test_segment_from_hgrid_invalid_axis_raises(get_rectilinear_hgrid):
     with pytest.raises(ValueError, match="axis must be one of"):
-        Boundary.from_hgrid(
+        Segment.from_hgrid(
             get_rectilinear_hgrid, axis="nx", index=0, segment_name="segment_001"
         )
 
 
-def test_boundary_from_hgrid_arbitrary_axis_index_range(get_rectilinear_hgrid):
+def test_segment_from_hgrid_arbitrary_axis_index_range(get_rectilinear_hgrid):
     hgrid = get_rectilinear_hgrid
     index_range = slice(2, 6)
-    boundary = Boundary.from_hgrid(
+    segment = Segment.from_hgrid(
         hgrid,
         axis="nyp",
         index=3,
@@ -272,14 +272,67 @@ def test_boundary_from_hgrid_arbitrary_axis_index_range(get_rectilinear_hgrid):
     )
     expected_lon = hgrid["x"].isel(nyp=3).isel(nxp=index_range)
     expected_lat = hgrid["y"].isel(nyp=3).isel(nxp=index_range)
-    assert np.allclose(boundary.lon.values, expected_lon.values)
-    assert np.allclose(boundary.lat.values, expected_lat.values)
-    assert boundary.lon.sizes["nx_segment_001"] == index_range.stop - index_range.start
+    assert np.allclose(segment.lon.values, expected_lon.values)
+    assert np.allclose(segment.lat.values, expected_lat.values)
+    assert segment.lon.sizes["nx_segment_001"] == index_range.stop - index_range.start
+
+
+@pytest.mark.parametrize(
+    "orientation,expected",
+    [
+        ("south", "J=0,I=0:N"),
+        ("north", "J=N,I=N:0"),
+        ("east", "I=N,J=0:N"),
+        ("west", "I=0,J=N:0"),
+    ],
+)
+def test_mom6_obc_position_string_matches_legacy_cardinal_convention(
+    get_rectilinear_hgrid, orientation, expected
+):
+    """Segment.cardinal's default MOM6 index string must match the values the
+    old hardcoded rect_MOM6_index_dir produced for the 4 cardinal boundaries,
+    including the ascending/descending convention and the 'N' sentinel."""
+    hgrid = get_rectilinear_hgrid
+    segment = Segment.cardinal(hgrid, orientation, "segment_001")
+    assert segment.mom6_obc_position_string() == expected
+
+
+def test_mom6_obc_position_string_arbitrary_segment(get_rectilinear_hgrid):
+    """An interior/partial segment (not a full outer edge) should get numeric
+    MOM6 model-grid indices -- half the supergrid index, per the supergrid's
+    2x resolution relative to MOM6's own model grid -- instead of the 'N'
+    sentinel, and reverse=True should flip the parallel index direction."""
+    hgrid = get_rectilinear_hgrid
+    segment = Segment.from_hgrid(
+        hgrid,
+        axis="nyp",
+        index=4,
+        segment_name="segment_002",
+        index_range=slice(2, 8),
+    )
+    assert segment.mom6_obc_position_string() == "J=2,I=1:3"
+    assert segment.mom6_obc_position_string(reverse=True) == "J=2,I=3:1"
+
+
+def test_mom6_obc_position_string_requires_grid_index():
+    """A hand-built Segment (no from_hgrid/cardinal) has no grid to derive
+    MOM6 indices from, so this should fail loudly rather than guess."""
+    segment = Segment(
+        lon=xr.DataArray([1.0, 2.0], dims=["nx_segment_099"]),
+        lat=xr.DataArray([1.0, 1.0], dims=["nx_segment_099"]),
+        angle=xr.DataArray([0.0, 0.0], dims=["nx_segment_099"]),
+        segment_name="segment_099",
+        parallel="nx",
+        perpendicular="ny",
+        axis_to_expand=2,
+    )
+    with pytest.raises(ValueError, match="grid-index bookkeeping"):
+        segment.mom6_obc_position_string()
 
 
 def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     """
-    Correctness test for Boundary.regrid_velocity_tracers.
+    Correctness test for Segment.regrid_velocity_tracers.
 
     Checks:
     - Output OBC file is written
@@ -304,7 +357,7 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     outfolder = tmp_path / "inputdir"
     outfolder.mkdir()
 
-    # Minimal synthetic boundary dataset covering the east edge of the hgrid (lon ≈ 10, lat 0-10)
+    # Minimal synthetic segment dataset covering the east edge of the hgrid (lon ≈ 10, lat 0-10)
 
     infile = tmp_path / "east_raw.nc"
     ds = toy_glorys_ds
@@ -322,8 +375,8 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    boundary = Boundary.cardinal(hgrid, "east", seg_name)
-    segment_out, _ = boundary.regrid_velocity_tracers(
+    segment = Segment.cardinal(hgrid, "east", seg_name)
+    segment_out, _ = segment.regrid_velocity_tracers(
         infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
 
@@ -336,8 +389,8 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     assert temp_vals[0, 0, 0, 0] == 22
     assert temp_vals[0, 0, 2, 0] == 26
 
-    boundary_north = Boundary.cardinal(hgrid, "north", seg_name)
-    segment_out_north, _ = boundary_north.regrid_velocity_tracers(
+    segment_north = Segment.cardinal(hgrid, "north", seg_name)
+    segment_out_north, _ = segment_north.regrid_velocity_tracers(
         infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
     temp_vals = segment_out_north[f"temp_{seg_name}"].values
@@ -353,8 +406,8 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     folder.mkdir()  # recreate the empty folder
     hgrid["x"] = hgrid.x + 1
     hgrid["y"] = hgrid.y + 1
-    boundary_regrid = Boundary.cardinal(hgrid, "west", seg_name)
-    seg_regridded, _ = boundary_regrid.regrid_velocity_tracers(
+    segment_regrid = Segment.cardinal(hgrid, "west", seg_name)
+    seg_regridded, _ = segment_regrid.regrid_velocity_tracers(
         infile,
         varnames,
         outfolder,
@@ -371,8 +424,8 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     )  # The bilinear regridding would be zero here because there isn't 4 points
 
 
-def test_boundary_standalone_no_hgrid(toy_glorys_ds, tmp_path):
-    """Prove regrid_velocity_tracers needs nothing beyond a hand-built Boundary --
+def test_segment_standalone_no_hgrid(toy_glorys_ds, tmp_path):
+    """Prove regrid_velocity_tracers needs nothing beyond a hand-built Segment --
     no mom6_forge.Grid, no hgrid, no Experiment involved at all."""
     outfolder = tmp_path / "inputdir"
     outfolder.mkdir()
@@ -394,9 +447,9 @@ def test_boundary_standalone_no_hgrid(toy_glorys_ds, tmp_path):
     }
 
     seg_name = "segment_099"
-    # A straight boundary line of 2 points, fully described by literal numbers --
+    # A straight segment line of 2 points, fully described by literal numbers --
     # lon fixed at 3.0 (inside toy_glorys_ds's [2, 4] lon range), lat spanning it.
-    boundary = Boundary(
+    segment = Segment(
         lon=xr.DataArray([3.0, 3.0], dims=[f"ny_{seg_name}"]),
         lat=xr.DataArray([2.5, 3.5], dims=[f"ny_{seg_name}"]),
         angle=xr.DataArray([0.0, 0.0], dims=[f"ny_{seg_name}"]),
@@ -407,7 +460,7 @@ def test_boundary_standalone_no_hgrid(toy_glorys_ds, tmp_path):
         mask=None,
     )
 
-    segment_out, _ = boundary.regrid_velocity_tracers(
+    segment_out, _ = segment.regrid_velocity_tracers(
         infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
 
@@ -416,7 +469,7 @@ def test_boundary_standalone_no_hgrid(toy_glorys_ds, tmp_path):
     np.testing.assert_allclose(segment_out[f"salt_{seg_name}"].values, 35.0, rtol=1e-4)
 
 
-def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
+def test_segment_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
     """regrid_velocity_tracers should only rebuild regridders when regridders=None
     -- passing back a previously-returned dict skips rebuilding, matching today's
     documented manual-reuse pattern."""
@@ -449,7 +502,7 @@ def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    boundary = Boundary.cardinal(hgrid, "east", "segment_001")
+    segment = Segment.cardinal(hgrid, "east", "segment_001")
 
     call_count = {"n": 0}
     real_create_vt_regridders = rgd.create_vt_regridders
@@ -460,13 +513,13 @@ def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
 
     monkeypatch.setattr(rgd, "create_vt_regridders", counting_create_vt_regridders)
 
-    _, _ = boundary.regrid_velocity_tracers(
+    _, _ = segment.regrid_velocity_tracers(
         infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
     )
     assert call_count["n"] == 1
-    cached_regridders = boundary._regridders
+    cached_regridders = segment._regridders
 
-    _, _ = boundary.regrid_velocity_tracers(
+    _, _ = segment.regrid_velocity_tracers(
         infile,
         varnames,
         outfolder,
@@ -479,7 +532,7 @@ def test_boundary_regridders_manual_reuse(toy_glorys_ds, tmp_path, monkeypatch):
 
 def _synthetic_tidal_datasets(nc=2):
     """Minimal synthetic TPXO-like elevation/velocity datasets, already in the
-    lon/lat/*Re/*Im form Boundary.regrid_tides expects -- skips the raw
+    lon/lat/*Re/*Im form Segment.regrid_tides expects -- skips the raw
     h_*/u_*-file parsing that experiment.setup_boundary_tides normally does
     (that parsing is covered separately by test_tides.py)."""
     nx, ny = 6, 6
@@ -504,12 +557,12 @@ def _synthetic_tidal_datasets(nc=2):
 
 
 def test_regrid_tides_standalone(get_rectilinear_hgrid, tmp_path):
-    """Boundary.regrid_tides should run against a plain Boundary (no Experiment
+    """Segment.regrid_tides should run against a plain Segment (no Experiment
     involved) and write tz_*/tu_* files, mirroring the existing standalone
     coverage of regrid_velocity_tracers."""
     hgrid = get_rectilinear_hgrid
     seg_name = "segment_001"
-    boundary = Boundary.cardinal(hgrid, "east", seg_name)
+    segment = Segment.cardinal(hgrid, "east", seg_name)
 
     tpxo_v, tpxo_u, tpxo_h = _synthetic_tidal_datasets()
     times = xr.DataArray(pd.date_range("2000-01-01", periods=1), dims=["time"])
@@ -517,7 +570,7 @@ def test_regrid_tides_standalone(get_rectilinear_hgrid, tmp_path):
     outfolder = tmp_path / "inputdir"
     outfolder.mkdir()
 
-    boundary.regrid_tides(
+    segment.regrid_tides(
         tpxo_v, tpxo_u, tpxo_h, times, outfolder, "2000-01-01 00:00:00"
     )
 
@@ -532,11 +585,11 @@ def test_regrid_tides_regridders_manual_reuse(
     get_rectilinear_hgrid, tmp_path, monkeypatch
 ):
     """regrid_tides should only rebuild its 3 regridders (elev/u/v) when
-    regridders=None -- passing back boundary._tidal_regridders from a prior
+    regridders=None -- passing back segment._tidal_regridders from a prior
     call skips rebuilding, matching the documented manual-reuse pattern for
     regrid_velocity_tracers."""
     hgrid = get_rectilinear_hgrid
-    boundary = Boundary.cardinal(hgrid, "east", "segment_001")
+    segment = Segment.cardinal(hgrid, "east", "segment_001")
 
     tpxo_v, tpxo_u, tpxo_h = _synthetic_tidal_datasets()
     times = xr.DataArray(pd.date_range("2000-01-01", periods=1), dims=["time"])
@@ -553,13 +606,13 @@ def test_regrid_tides_regridders_manual_reuse(
 
     monkeypatch.setattr(rgd, "create_regridder", counting_create_regridder)
 
-    boundary.regrid_tides(
+    segment.regrid_tides(
         tpxo_v, tpxo_u, tpxo_h, times, outfolder, "2000-01-01 00:00:00"
     )
     assert call_count["n"] == 3  # elev, u, v
-    cached_regridders = boundary._tidal_regridders
+    cached_regridders = segment._tidal_regridders
 
-    boundary.regrid_tides(
+    segment.regrid_tides(
         tpxo_v,
         tpxo_u,
         tpxo_h,

--- a/tests/test_segment_multi_boundary_domain.py
+++ b/tests/test_segment_multi_boundary_domain.py
@@ -106,7 +106,11 @@ def test_sketch_domain_segment_masks_match_supergridmask_slices():
     for name, seg in segments.items():
         if name in _SKETCH_CARDINAL_SEGMENTS:
             spec = None
-            axis = "nyp" if _SKETCH_CARDINAL_SEGMENTS[name] in ("south", "north") else "nxp"
+            axis = (
+                "nyp"
+                if _SKETCH_CARDINAL_SEGMENTS[name] in ("south", "north")
+                else "nxp"
+            )
             index = {"south": 0, "north": -1, "west": 0, "east": -1}[
                 _SKETCH_CARDINAL_SEGMENTS[name]
             ]
@@ -197,9 +201,9 @@ def test_sketch_domain_position_strings_full_edge_vs_interior():
     assert segments["segment_005"].mom6_obc_position_string() == "I=N,J=0:4"
     for name in ("segment_001", "segment_003", "segment_005", "segment_004"):
         parallel = segments[name].mom6_obc_position_string().split(",")[1]
-        assert parallel != "I=0:N" and parallel != "J=0:N", (
-            f"{name} shouldn't span the *whole* parallel edge like a cardinal segment: {parallel}"
-        )
+        assert (
+            parallel != "I=0:N" and parallel != "J=0:N"
+        ), f"{name} shouldn't span the *whole* parallel edge like a cardinal segment: {parallel}"
 
 
 def test_interior_partial_segment_regrid_velocity_tracers(toy_glorys_ds, tmp_path):

--- a/tests/test_segment_multi_boundary_domain.py
+++ b/tests/test_segment_multi_boundary_domain.py
@@ -1,0 +1,266 @@
+"""Coverage for Segment.from_hgrid/cardinal on a domain with many segments --
+full edges, partial edges, and fully interior lines -- next to irregular
+"discarded domain" land patches (headlands), matching a hand-sketched design
+with these properties: extents of neighbouring segments may overlap, segment
+construction order carries no meaning, and land masking comes straight from a
+mom6_forge.Topo -- all exercised without ever touching regional_mom6.experiment.
+"""
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
+from regional_mom6.segment import Segment
+
+
+def _sketch_grid_and_topo():
+    """A 20x20 T-cell rectilinear domain with two irregular headlands carved
+    out of it (each with a one-cell notch, so neither is a plain rectangle):
+      - Headland A: rows (t-index) 15-19, cols 7-13, notch at (15, 10).
+      - Headland B: rows 0-4, cols 15-19, notch at (2, 17).
+    """
+    grid = Grid(
+        resolution=1,
+        xstart=0,
+        lenx=20,
+        ystart=0,
+        leny=20,
+        name="sketch_domain",
+        type="rectilinear_cartesian",
+    )
+    topo = Topo(grid, min_depth=5.0, git=False)
+    topo.set_flat(100.0)
+
+    depth = topo.depth.values.copy()
+    depth[15:20, 7:14] = 0.0
+    depth[15, 10] = 100.0  # notch back to ocean
+    depth[0:5, 15:20] = 0.0
+    depth[2, 17] = 100.0  # notch back to ocean
+    topo.depth = depth
+    return grid, topo
+
+
+# (segment_name, kwargs for Segment.from_hgrid, or None to use Segment.cardinal)
+_SKETCH_SEGMENT_SPECS = {
+    "segment_001": dict(
+        axis="nyp", index=-1, index_range=slice(0, 14)
+    ),  # north edge, west of headland A
+    "segment_002": dict(
+        axis="nyp", index=30, index_range=slice(8, 40), mom6_index_reverse=True
+    ),  # interior line just south of headland A; overlaps segment_001 in columns 4-6
+    "segment_003": dict(
+        axis="nxp", index=-1, index_range=slice(10, 41)
+    ),  # east edge, above headland B
+    "segment_004": dict(
+        axis="nxp", index=30, index_range=slice(0, 10)
+    ),  # interior line, west edge of headland B
+    "segment_005": dict(
+        axis="nxp", index=-1, index_range=slice(0, 10)
+    ),  # east edge, alongside headland B
+}
+_SKETCH_CARDINAL_SEGMENTS = {
+    "segment_006": "south",
+    "segment_007": "west",
+}
+
+
+def _build_all_segments(hgrid, topo, order):
+    segments = {}
+    for name in order:
+        if name in _SKETCH_CARDINAL_SEGMENTS:
+            segments[name] = Segment.cardinal(
+                hgrid, _SKETCH_CARDINAL_SEGMENTS[name], name, topo=topo
+            )
+        else:
+            segments[name] = Segment.from_hgrid(
+                hgrid, segment_name=name, topo=topo, **_SKETCH_SEGMENT_SPECS[name]
+            )
+    return segments
+
+
+def test_sketch_domain_seven_segments_built_standalone():
+    """All 7 segments from the sketch build cleanly via Segment alone -- no
+    regional_mom6.experiment involved -- covering full edges (006, 007),
+    partial edges (001, 003, 005), and fully interior lines (002, 004)."""
+    grid, topo = _sketch_grid_and_topo()
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+
+    all_names = list(_SKETCH_SEGMENT_SPECS) + list(_SKETCH_CARDINAL_SEGMENTS)
+    assert len(all_names) == 7
+
+    segments = _build_all_segments(hgrid, topo, all_names)
+    assert set(segments) == set(all_names)
+
+
+def test_sketch_domain_segment_masks_match_supergridmask_slices():
+    """Every segment's mask -- full-edge, partial-edge, or interior -- is
+    exactly topo.supergridmask sliced the same way, headland notches included."""
+    grid, topo = _sketch_grid_and_topo()
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+    segments = _build_all_segments(
+        hgrid, topo, list(_SKETCH_SEGMENT_SPECS) + list(_SKETCH_CARDINAL_SEGMENTS)
+    )
+
+    for name, seg in segments.items():
+        if name in _SKETCH_CARDINAL_SEGMENTS:
+            spec = None
+            axis = "nyp" if _SKETCH_CARDINAL_SEGMENTS[name] in ("south", "north") else "nxp"
+            index = {"south": 0, "north": -1, "west": 0, "east": -1}[
+                _SKETCH_CARDINAL_SEGMENTS[name]
+            ]
+            index_range = None
+        else:
+            spec = _SKETCH_SEGMENT_SPECS[name]
+            axis, index, index_range = spec["axis"], spec["index"], spec["index_range"]
+
+        expected = topo.supergridmask.isel({axis: index})
+        if index_range is not None:
+            parallel_axis = "nxp" if axis == "nyp" else "nyp"
+            expected = expected.isel({parallel_axis: index_range})
+        assert (seg.mask.values == expected.values).all(), f"{name} mask mismatch"
+        # Headland masking actually did something -- not every point is ocean.
+        if name in ("segment_002", "segment_004"):
+            assert (seg.mask.values == 0).any(), f"{name} should touch masked land"
+
+
+def test_sketch_domain_segment_extents_may_overlap():
+    """segment_001 (north edge, west portion) and segment_002 (interior line
+    just south of headland A) deliberately share part of their column range --
+    building both must not raise or otherwise reject the overlap."""
+    grid, topo = _sketch_grid_and_topo()
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+    segments = _build_all_segments(hgrid, topo, ["segment_001", "segment_002"])
+
+    lon_1 = set(np.round(segments["segment_001"].lon.values, 6))
+    lon_2 = set(np.round(segments["segment_002"].lon.values, 6))
+    assert lon_1 & lon_2, "segment_001 and segment_002 should overlap in longitude"
+
+
+def test_sketch_domain_segment_construction_order_is_irrelevant():
+    """The sketch notes there's no required order to segment orientation/
+    construction -- building the same 7 segments in two unrelated orders must
+    give bit-identical results per segment name."""
+    grid, topo = _sketch_grid_and_topo()
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+    all_names = list(_SKETCH_SEGMENT_SPECS) + list(_SKETCH_CARDINAL_SEGMENTS)
+
+    order_a = all_names  # 001..007 in sketch order
+    order_b = [
+        "segment_004",
+        "segment_007",
+        "segment_002",
+        "segment_006",
+        "segment_001",
+        "segment_005",
+        "segment_003",
+    ]
+    assert set(order_a) == set(order_b)
+
+    segments_a = _build_all_segments(hgrid, topo, order_a)
+    segments_b = _build_all_segments(hgrid, topo, order_b)
+
+    for name in all_names:
+        a, b = segments_a[name], segments_b[name]
+        assert np.array_equal(a.lon.values, b.lon.values)
+        assert np.array_equal(a.lat.values, b.lat.values)
+        assert np.array_equal(a.mask.values, b.mask.values)
+        assert a.mom6_obc_position_string() == b.mom6_obc_position_string()
+
+
+def test_sketch_domain_position_strings_full_edge_vs_interior():
+    """Full-edge segments emit MOM6's 'N' sentinel (matching the legacy
+    cardinal convention); interior/partial segments emit numeric indices."""
+    grid, topo = _sketch_grid_and_topo()
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+    segments = _build_all_segments(
+        hgrid, topo, list(_SKETCH_SEGMENT_SPECS) + list(_SKETCH_CARDINAL_SEGMENTS)
+    )
+
+    # Full outer edges: same convention as the 4 legacy cardinal boundaries.
+    assert segments["segment_006"].mom6_obc_position_string() == "J=0,I=0:N"
+    assert segments["segment_007"].mom6_obc_position_string() == "I=0,J=N:0"
+
+    # Interior line (axis="nyp", index=30, index_range=slice(8, 40), reverse=True):
+    # fixed J = 30 // 2 = 15; parallel I = 8//2=4 .. (40-1)//2=19, reversed -> 19:4.
+    assert segments["segment_002"].mom6_obc_position_string() == "J=15,I=19:4"
+    # Interior line adjacent to headland B (axis="nxp", index=30, index_range=slice(0,10)).
+    assert segments["segment_004"].mom6_obc_position_string() == "I=15,J=0:4"
+
+    # Partial edges: the *fixed* coordinate is still "N" (it's a real edge row/
+    # column), but the *parallel* (index_range-restricted) coordinate is only
+    # "N" on the side that happens to reach the domain boundary -- never on
+    # both sides at once the way a full cardinal edge would.
+    assert segments["segment_001"].mom6_obc_position_string() == "J=N,I=0:6"
+    assert segments["segment_003"].mom6_obc_position_string() == "I=N,J=5:N"
+    assert segments["segment_005"].mom6_obc_position_string() == "I=N,J=0:4"
+    for name in ("segment_001", "segment_003", "segment_005", "segment_004"):
+        parallel = segments[name].mom6_obc_position_string().split(",")[1]
+        assert parallel != "I=0:N" and parallel != "J=0:N", (
+            f"{name} shouldn't span the *whole* parallel edge like a cardinal segment: {parallel}"
+        )
+
+
+def test_interior_partial_segment_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
+    """Beyond geometry: an interior, partially-masked segment (not a cardinal
+    edge) round-trips through the actual regridding path, same as a cardinal
+    segment would."""
+    grid = Grid(
+        resolution=1,
+        xstart=2,
+        lenx=4,
+        ystart=2,
+        leny=4,
+        name="interior_regrid_test",
+        type="rectilinear_cartesian",
+    )
+    topo = Topo(grid, min_depth=5.0, git=False)
+    topo.set_flat(100.0)
+    depth = topo.depth.values.copy()
+    depth[2, 2] = 0.0  # mask one interior T-cell along the segment's line to land
+    topo.depth = depth
+    hgrid = grid._supergrid.to_ds(name=grid.name, author="pytest")
+
+    seg_name = "segment_010"
+    outfolder = tmp_path / "inputdir"
+    outfolder.mkdir()
+    infile = tmp_path / "raw.nc"
+    ds = toy_glorys_ds
+    ds.to_netcdf(infile)
+    ds.close()
+
+    varnames = {
+        "xh": "lon",
+        "yh": "lat",
+        "time": "time",
+        "eta": "eta",
+        "zl": "depth",
+        "u": "u",
+        "v": "v",
+        "tracers": {"temp": "temp", "salt": "salt"},
+    }
+
+    # axis="nyp", index=4 is an interior line (neither 0 nor the last index),
+    # index_range restricts it to part of the domain's width -- exactly the
+    # "not a cardinal edge" case the sketch is about.
+    segment = Segment.from_hgrid(
+        hgrid,
+        axis="nyp",
+        index=4,
+        segment_name=seg_name,
+        index_range=slice(2, 7),
+        topo=topo,
+    )
+    assert (segment.mask.values == 0).any(), "segment should cross the masked cell"
+
+    segment_out, _ = segment.regrid_velocity_tracers(
+        infile, varnames, outfolder, "2003-01-01 00:00:00", arakawa_grid="A"
+    )
+
+    salt_vals = segment_out[f"salt_{seg_name}"].values
+    ocean_points = segment.mask.values.astype(bool)
+    # Salt is spatially constant at 35 in toy_glorys_ds -- ocean points should
+    # match; masked land points are filled, not physically meaningful.
+    np.testing.assert_allclose(salt_vals[..., ocean_points], 35.0, rtol=1e-4)
+    assert np.isfinite(salt_vals).all()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from regional_mom6.utils import get_edge
-
 V1 = np.zeros((2, 4, 3))
 V2 = np.zeros((2, 4, 3))
 true_V1dotV2 = np.zeros((2, 4))
@@ -15,15 +13,3 @@ for i in np.arange(2):
             V2[i, j, k] = 1.0 * np.array(i + j + k + 1)
             sum += -(2 * i - 3 * j + 2 * k) * (i + j + k + 1)
             true_V1dotV2[i, j] = float(sum)
-
-
-def test_get_edge(get_rectilinear_hgrid):
-    hgrid = get_rectilinear_hgrid
-    res = get_edge(hgrid, "north")
-    assert (res.x == hgrid.x.isel(nyp=-1)).all()
-    res = get_edge(hgrid, "south")
-    assert (res.x == hgrid.x.isel(nyp=0)).all()
-    res = get_edge(hgrid, "east")
-    assert (res.x == hgrid.x.isel(nxp=-1)).all()
-    res = get_edge(hgrid, "west")
-    assert (res.x == hgrid.x.isel(nxp=0)).all()


### PR DESCRIPTION
## Summary

- `Experiment.boundaries` can now mix cardinal direction strings (`"south"`/`"north"`/`"west"`/`"east"`) with `Segment` instances describing interior or partial-edge OBC lines (built via `Segment.from_hgrid`/`Segment.from_lonlat`), instead of being restricted to up to 4 cardinal edges.
- Segments are numbered purely by position in `boundaries` (1..N) rather than by cardinal orientation, so numbering behaves the same regardless of shape.
- `_get_segment` now builds a cardinal `Segment` as before, or re-cuts a supplied `Segment` to the canonical `segment_{i:03d}` name via its existing `to_spec()`/`from_spec()` round-trip.
- Fixed a latent zero-padding bug in `setup_generic`'s MOM_override writing (`OBC_SEGMENT_00{n}` assumed a single-digit `n`); now zero-pads to 3 digits throughout, so more than 9 segments works correctly.
- Added `_validate_boundary_orientations()`, run at the start of `setup_generic`: for each interior `Segment`, it samples the bathymetry mask on both sides of the line and, only when unambiguous (land clearly on one side), checks the segment's `mom6_index_reverse` against MOM6's counter-clockwise-interior OBC convention ([MOM6 OBC wiki](https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions)), raising a clear error if it's backwards. Genuinely ambiguous cases (e.g. a pure open-ocean interior cut) are silently allowed through, and the check is skipped entirely if bathymetry hasn't been set up yet.

This builds directly on the existing `Segment` refactor (`Segment.from_hgrid`/`from_lonlat`/`to_spec`/`from_spec`, tested standalone in `tests/test_segment_multi_boundary_domain.py`), which `Experiment` had not yet been wired up to use.

## Test plan

- [x] `pytest tests/test_expt_class.py tests/test_segment_multi_boundary_domain.py -vv` — updated 2 existing tests for the new `_get_segment`/numbering signatures, added 2 new tests (list-position numbering with a mixed cardinal+interior boundary list; orientation-validation error on a deliberately-flipped interior segment).
- [x] Full suite: `pytest tests/` — 74 passed, 2 skipped (pre-existing), no failures.
- [x] `black regional_mom6/ tests/`