### PR TITLE
Implement init_eta property for dataset loading

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -597,6 +597,20 @@ class experiment:
             return
 
     @property
+    def init_eta(self):
+        try:
+            return xr.open_dataset(
+                self.mom_input_dir / "init_eta.nc",
+                decode_cf=False,
+                decode_times=False,
+            )
+        except Exception as e:
+            print(
+                f"Error: {e}. Opening init_eta threw an error! Make sure you've successfully run the setup_initial_condition method, or copied an init_eta.nc file into {self.mom_input_dir}."
+            )
+            return
+
+    @property
     def ocean_state_boundary_paths(self):
         """
         Finds the ocean state files from disk, and prints the file paths


### PR DESCRIPTION
init_vel and init_tracers have a property so that you can read them and plot them with `expt.init_vel.u.plot()`. No reason not to do the same for sea surface height, so we can plot that in the demo notebooks the same way